### PR TITLE
避免对未成功获取（未初始化）的 AVPacket 进行释放

### DIFF
--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -148,14 +148,18 @@ int PlayThread::audio_decode_frame(mediaState* MS, uint8_t* audio_buf)
 
     int returns = -1; //除非音频解码成功返回音频数据，否则返回 -1
 
+    if (packet_queue_get(&MS->audioq, &packet, 0) < 0)
+    {
+        qDebug()<<"PlayThread::audio_decode_frame: no packet got";
+        return returns;
+    }
+
+
     while (true)
     {
-        if (packet_queue_get(&MS->audioq, &packet, 0) < 0)
-        {
-            break;
-        }
         if (packet.pts == AV_NOPTS_VALUE)
         {
+            // useless ?
             break;
         }
 


### PR DESCRIPTION
Fixed #51
Patch for 0175326182c6d4e284cd23c657480e6bbf18b896

<br>

本 PR 修复的问题在 Windows 平台上似乎是不存在的：

| 操作系统 | 编译器 | FFmpeg | 是否复现 #51 |
| - | - | -:|:-:|
| Windows 10 | Microsoft (R) C/C++ Optimizing Compiler Version 19.00.24234.1 for x86 | 4.0.1/4.2.2 | X |
| Windows 7 | Microsoft (R) C/C++ Optimizing Compiler Version 19.24.28314 for x86 | 4.0.1/4.2.2 | X |
| Ubuntu 18.04 | gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)  | 4.2.2 | O |
| macOS 10.14 | Apple LLVM version 10.0.0 (clang-1000.10.44.4) | 4.2.2 | O |