### PR TITLE
移除对 SDL2main 库的链接

### DIFF
--- a/Entities/MP3Editor/mp3Editor.pri
+++ b/Entities/MP3Editor/mp3Editor.pri
@@ -44,7 +44,7 @@ LIBS += -L$$FFMPEG_LIB/ -lavcodec\
         -L$$FFMPEG_LIB/ -lswresample \
         -L$$FFMPEG_LIB/ -lswscale \
         -L$$FFMPEG_LIB/ -lswresample \
-        -L$$SDL_LIB/ -lSDL2main  \
+#        -L$$SDL_LIB/ -lSDL2main  \
         -L$$SDL_LIB/ -lSDL2
 }
 
@@ -76,7 +76,7 @@ LIBS += $$FFMPEG_LIB/libavcodec.so      \
         $$FFMPEG_LIB/libswresample.so   \
         $$FFMPEG_LIB/libswscale.so      \
         #$$FFMPEG_LIB/libpostproc.so    \
-        -L$$SDL_LIB/ -lSDL2main        \   #can't be $$PSDL_LIB/ -lSDL2main, must be -L$$PSDL_LIB/ -lSDL2main
+#        -L$$SDL_LIB/ -lSDL2main        \   #can't be $$PSDL_LIB/ -lSDL2main, must be -L$$PSDL_LIB/ -lSDL2main
         -L$$SDL_LIB/ -lSDL2
 }
 
@@ -103,7 +103,7 @@ LIBS += -L$$FFMPEG_LIB/ -lavcodec      \
         -L$$FFMPEG_LIB/ -lavutil       \
         -L$$FFMPEG_LIB/ -lswresample   \
         -L$$FFMPEG_LIB/ -lswscale   \
-        -L$$SDL_LIB/ -lSDL2main        \
+#        -L$$SDL_LIB/ -lSDL2main        \
         -L$$SDL_LIB/ -lSDL2
 
 }

--- a/Entities/MusicPlayer/musicPlayer.pri
+++ b/Entities/MusicPlayer/musicPlayer.pri
@@ -43,7 +43,7 @@ LIBS += -L$$FFMPEG_LIB/ -lavcodec\
         -L$$FFMPEG_LIB/ -lswresample \
         -L$$FFMPEG_LIB/ -lswscale \
         -L$$FFMPEG_LIB/ -lswresample \
-        -L$$SDL_LIB/ -lSDL2main  \
+#        -L$$SDL_LIB/ -lSDL2main  \
         -L$$SDL_LIB/ -lSDL2
 }
 
@@ -75,7 +75,7 @@ LIBS += $$FFMPEG_LIB/libavcodec.so      \
         $$FFMPEG_LIB/libswresample.so   \
         $$FFMPEG_LIB/libswscale.so      \
         #$$FFMPEG_LIB/libpostproc.so    \
-        -L$$SDL_LIB/ -lSDL2main        \   #can't be $$PSDL_LIB/ -lSDL2main, must be -L$$PSDL_LIB/ -lSDL2main
+#        -L$$SDL_LIB/ -lSDL2main        \   #can't be $$PSDL_LIB/ -lSDL2main, must be -L$$PSDL_LIB/ -lSDL2main
         -L$$SDL_LIB/ -lSDL2
 }
 
@@ -102,7 +102,7 @@ LIBS += -L$$FFMPEG_LIB/ -lavcodec      \
         -L$$FFMPEG_LIB/ -lavutil       \
         -L$$FFMPEG_LIB/ -lswresample   \
         -L$$FFMPEG_LIB/ -lswscale   \
-        -L$$SDL_LIB/ -lSDL2main        \
+#        -L$$SDL_LIB/ -lSDL2main        \
         -L$$SDL_LIB/ -lSDL2
 
 }


### PR DESCRIPTION
在使用 MSVC v141 及以上版本时，链接报错：

```
SDL2main.lib(SDL_windows_main.obj) : error LNK2005: _main already defined in main.obj
MSVCRTD.lib(initializers.obj) : warning LNK4098: defaultlib 'msvcrt.lib' conflicts with use of other libs; use /NODEFAULTLIB:library
LINK : warning LNK4217: symbol '_fprintf' defined in 'mp3Editor.obj' is imported by 'SDL2main.lib(SDL_windows_main.obj)' in function '_ShowError'
SDL2main.lib(SDL_windows_main.obj) : error LNK2019: unresolved external symbol _SDL_main referenced in function _main
SDL2main.lib(SDL_windows_main.obj) : error LNK2019: unresolved external symbol __imp____iob_func referenced in function _ShowError
debug\Beslyric-for-X.exe : fatal error LNK1120: 2 unresolved externals
```

分析后得出：Beslyric-for-X （以下简称 B4X ）使用[`SDL_Init(Uint32 flags)`](http://wiki.libsdl.org/SDL_Init)方法初始化 SDL ，同时也不在入口`int main(int argc, char* argv[])`初始化 SDL ，不需要`SDL_main`的相关功能。

---

如果 B4X 引入`SDL_main`，简略地说，有三件事情要发生：

- 检查宏`SDL_MAIN_HANDLED`是否存在，如果没有，就定义宏`SDL_MAIN_NEEDED`或宏`SDL_MAIN_AVAILABLE`（根据平台类型）；
- 如果宏`SDL_MAIN_NEEDED`或宏`SDL_MAIN_AVAILABLE`存在，则使用宏定义`#define main    SDL_main`将 B4X 的入口重命名为`int SDL_main(int argc, char *argv[])`；
- 程序启动时，将首先调用 SDL 的`int main(int argc, char* argv[])`，待 SDL 初始化后，再调用`int SDL_main(int argc, char* argv[])`启动 B4X 。

源码：

0. `#define main    SDL_main`：
https://github.com/spurious/SDL-mirror/blob/release-2.0.3/include/SDL_main.h#L94-L96
1. SDL 的`int main(int argc, char* argv[])`的原型：
https://github.com/spurious/SDL-mirror/blob/release-2.0.3/src/main/dummy/SDL_dummy_main.c#L11-L15
2. 用于 MSVC 的 SDL 的`int main(int argc, char* argv[])`：
https://github.com/spurious/SDL-mirror/blob/release-2.0.3/src/main/windows/SDL_windows_main.c#L131-L147

参考：

- https://forums.libsdl.org/viewtopic.php?p=6763#6763
- https://stackoverflow.com/questions/6847360/error-lnk2019-unresolved-external-symbol-main-referenced-in-function-tmainc
- https://stackoverflow.com/questions/11976084/why-sdl-defines-main-macro

---

本 PR 在 Ubuntu 18.04 、 Windows 7 / 10 、 macOS 10.14 / 10.15 测试通过。
