### PR TITLE
使用“ DESTDIR ”变量分离二进制文件

### DIFF
--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -84,6 +84,16 @@ ICON = Beslyric.icns
 
 #--------------------------------
 
+# Separate the binary file.
+CONFIG(debug, debug|release){
+    DESTDIR = $${OUT_PWD}/debug_bin
+}
+CONFIG(release, debug|release){
+    DESTDIR = $${OUT_PWD}/release_bin
+}
+
+#--------------------------------
+
 #屏蔽 msvc 编译器对 rational.h 的 warning: C4819: 该文件包含不能在当前代码页(936)中表示的字符。请将该文件保存为 Unicode 格式以防止数据丢失
 win32-msvc*:QMAKE_CXXFLAGS += /wd"4819"
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ IDE: [QT Creator 5.7.1](https://download.qt.io/archive/qt/5.7/5.7.1/)
 
 2、本项目使用跨平台开源库 ffmpeg 解析播放音频文件，考虑到更新ffmpeg的灵活性 以及 跨平台要求的特性，Beslyric-for-X 中在使用 ffmpeg 时，不直接将其置于项目下，而是开发者在对应的平台上各自独立单独安装。具体开发说明置于 [beslyric-lib](https://github.com/BensonLaur/beslyric-lib) 项目中。
 
+#### 输出
+
+1. 生成的二进制文件在输出目录的`[ debug | release ]_bin`文件夹下。
+


### PR DESCRIPTION
本 PR 拆分至 #35 ，经过 #54 的尝试，最后由 https://github.com/BensonLaur/Beslyric-for-X/pull/35#issuecomment-585542773 定好方向。

---

无论是否有`debug_and_release`或`debug_and_release_target`标志，也不管是否启用 Shadow build ，输出的文件始终都位于`$${OUT_PWD}/[ debug | release ]_bin`文件夹，方便后续的操作（例如使用 windeployqt 部署 Qt 库或使用 Inno Setup 提取文件）。

经测试，`debug_and_release_target`的作用会被`$$DESTDIR`覆盖。

---

本 PR 已在以下环境通过测试：
- Qt 5.14.1 (macOS 10.15, Windows 10 1903, Windows 10 1909, Ubuntu 18.04.3 and Ubuntu 18.04.4)
- Qt 5.13.2 (macOS 10.14)
- Qt 5.9.8 (Windows 10 1903 and Ubuntu 18.04.3)

---

一些有序或者杂乱的资料：
- [qmake Manual](https://doc.qt.io/qt-5/qmake-manual.html)
- [Undocumented QMake - Qt Wiki](https://wiki.qt.io/Undocumented_QMake)
- [Technical FAQ - Qt Wiki](https://wiki.qt.io/Technical_FAQ)