### PR TITLE
使 Ubuntu 将输出文件识别为可执行程序

### DIFF
--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -75,6 +75,13 @@ macx{
 ICON = Beslyric.icns
 }
 
+# ubuntu icon recoginition
+#  No test on other Linux distros!
+# from: https://stackoverflow.com/questions/45329372/ubuntu-recognizes-executable-as-shared-library-and-wont-run-it-by-clicking
+!macx:unix{
+    QMAKE_LFLAGS *= -no-pie
+}
+
 #--------------------------------
 
 #屏蔽 msvc 编译器对 rational.h 的 warning: C4819: 该文件包含不能在当前代码页(936)中表示的字符。请将该文件保存为 Unicode 格式以防止数据丢失


### PR DESCRIPTION
添加`-no-pie`标志到[`QMAKE_LFLAGS`](https://doc.qt.io/qt-5/qmake-variable-reference.html#qmake-lflags)，使 Ubuntu 认为输出的二进制文件是可执行文件而不是动态链接库（共享库、共享链接库），进而使输出文件能被双击运行，同时显示为可执行程序的图标。

| | before | after |
| - |:- |:- |
| "Properties..." | shared library (application/x-sharedlib) | executable (application/x-executable) |
| `file` | ELF 64-bit LSB shared object, x86-64, version 1 (GNU/Linux), dynamically linked | ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), dynamically linked |

参考：
- https://stackoverflow.com/questions/45329372/ubuntu-recognizes-executable-as-shared-library-and-wont-run-it-by-clicking
- https://forum.qt.io/topic/70710/wrong-executable-generation-in-release-mode
- https://forum.qt.io/topic/80690/solved-debian-9-qt-program-compile
- https://forum.qt.io/topic/84422/sharedlib-instead-of-executable-file-on-ubuntu

---

本 PR 在 gcc version 7.4.0 (Ubuntu 18.04.3 and Ubuntu 18.04.4) 通过测试。