### PR TITLE
避免大于音频当前播放时间的“提前毫秒数”使歌词时间戳为负

### DIFF
--- a/Entities/LyricMaker.cpp
+++ b/Entities/LyricMaker.cpp
@@ -242,7 +242,12 @@ bool LyricMaker::updateCurrentLineText(QString& line)
 //标记当前行为 time
 bool LyricMaker::markCurrentRawLine(quint64 time)
 {
-    time -= insertOffsetTime;
+    // warning: comparison of integers of different sign
+    if(time < insertOffsetTime){
+        time = 0;
+    }else{
+        time -= insertOffsetTime;
+    }
     lrcLines.push_back(QPair<quint64, QString>(time,rawLines[rawCurrent]));
 
     rawCurrent++;
@@ -257,7 +262,12 @@ bool LyricMaker::markEmptyLine(quint64 time)
     //只有当lrc 歌词为空，或者不为空时最后一个元素的内容不为空时，才插入一个空的时间行
     if(lrcLines.isEmpty() || lrcLines.last().second != "")
     {
-        time -= insertOffsetTime;
+        // warning: comparison of integers of different signs
+        if(time < insertOffsetTime){
+            time = 0;
+        }else{
+            time -= insertOffsetTime;
+        }
         lrcLines.push_back(QPair<quint64, QString>(time,""));
         lrcNext++;
     }

--- a/MiddleWidgets/SubPageMaking.cpp
+++ b/MiddleWidgets/SubPageMaking.cpp
@@ -770,7 +770,6 @@ void SubPageMaking::startMaking()
     if(isMaking == false)  //没有在制作时才允许响应制作的操作
     {
         isMaking = true;
-	curAudioPos = 0; //初始化标记歌词时间使用的时间值
 
         emit onStartMaking();
 


### PR DESCRIPTION
Fixed #65 
Reversed 8b5141f5ba94899ea2e6ae3fb235f0459abcf671

@BensonLaur @ish-kafel 

---

#65 与`curAudioPos`关系不大，故撤销上一个提交（不过，没有为`curAudioPos`赋初值的确会造成潜在的问题）。

<br>

实际上，无论是哪一句歌词，只要`insertOffsetTime`大于音频的当前播放时间，由于盲目的计算`time -= insertOffsetTime`，都会使计算出的时间戳为负值。

---

注意，**出现负值的根本原因是程序中数据类型的混乱**，代码如下：

https://github.com/Beslyric-for-X/Beslyric-for-X/blob/8b5141f5ba94899ea2e6ae3fb235f0459abcf671/Entities/LyricMaker.cpp#L319-L337

证明：
1. `quint64`类型最大值为`18446744073709551615`，`int`类型范围为`-2147483648`到`2147483647`，共`4294967296`个数；
2. 在`18446744073709551615`进行两次除法运算（分别除以`1000`和`60`）后，值为`307445734561825`；
3. 通过取模（这里也可以称为取余，因为同号）运算`307445734561825 % 4294967296`，值为`3385579553`，即对于`unsigned int`类型，结果为`3385579553`；
4. 由于输出时转换为`int`类型（`%.2d`），又因为`3385579553`>`2147483647`，所以结果为负数；
5. `3385579553 - 2147483647`结果为`1238095906`，即从`-2147483648`算起第 1238095906 个数，即`-2147483648 + 1238095906 - 1`，结果为`-909387743`。

---

在搜索引擎里搜索`909387743`，能看到有多少歌词受到了这个 BUG 的影响。

---

本 PR 能够帮助到未来的一个需求： #66 。