### PR TITLE
注释对 AVPacket 的无用测试以避免段错误

### DIFF
--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -117,10 +117,11 @@ void packet_queue_flush(PacketQueue *q)
     for(pkt = q->first_pkt; pkt != NULL; pkt = pkt1)
     {
         pkt1 = pkt->next;
-        if(pkt1->pkt.data != (uint8_t *)"FLUSH")
-        {
-            ;
-        }
+        // Crashed on macOS
+//        if(pkt1->pkt.data != (uint8_t *)"FLUSH")
+//        {
+//            ;
+//        }
         av_free_packet(&pkt->pkt);
         av_freep(&pkt);
 


### PR DESCRIPTION
Fixed #37

---

原因：

- 在 macOS 10.14+ 进行 seek 或重新播放时，`pkt1`为`null`；
- 这个`if`语句没有实际作用。
