### PR TITLE
消除时间相关存储类型不一致导致的 warning

### DIFF
--- a/BesWidgets/table/FinishLrcTableModel.h
+++ b/BesWidgets/table/FinishLrcTableModel.h
@@ -23,8 +23,8 @@ public:
     void deleteAllItems();
     void appendItems(const QVector<LyricInfo>& infos);
 
-    void setLyricLines(QVector<QPair<quint64, QString>>* _pLrcLines){pLrcLines = _pLrcLines;}
-    QVector<QPair<quint64, QString>>* getLyricLines(){return pLrcLines;}
+    void setLyricLines(QVector<QPair<qint64, QString>>* _pLrcLines){pLrcLines = _pLrcLines;}
+    QVector<QPair<qint64, QString>>* getLyricLines(){return pLrcLines;}
 signals:
 
 public slots:
@@ -34,7 +34,7 @@ private:
     QStringList m_HorizontalHeader;
     QVector<LyricInfo> m_data;
 
-    QVector<QPair<quint64, QString>>* pLrcLines;
+    QVector<QPair<qint64, QString>>* pLrcLines;
 };
 
 #endif // FinishLrcTableModel_H

--- a/BesWidgets/table/FinishLrcTableView.cpp
+++ b/BesWidgets/table/FinishLrcTableView.cpp
@@ -32,7 +32,7 @@ void FinishLrcTableView::appendItems(const QVector<LyricInfo>& infos)
 }
 
 
-void FinishLrcTableView::setLyricData(QVector<QPair<quint64, QString>>* pLrcLines)
+void FinishLrcTableView::setLyricData(QVector<QPair<qint64, QString>>* pLrcLines)
 {
     m_model->setLyricLines(pLrcLines);
     emit m_model->layoutChanged();
@@ -45,7 +45,7 @@ QVector<QString> FinishLrcTableView::getSelectedLrc()
     QVector<QString> vecLines;
     if(indexList.size() != 0)
     {
-        QVector<QPair<quint64, QString>>* pLrc = m_model->getLyricLines();
+        QVector<QPair<qint64, QString>>* pLrc = m_model->getLyricLines();
 
         if(pLrc)
         {
@@ -66,7 +66,7 @@ void FinishLrcTableView::onEditRow(int row)
 {
     //弹框改变已有lrc歌词内容
     BesEditDialog besEditDialog;
-    QVector<QPair<quint64, QString>>* pLrc = m_model->getLyricLines();
+    QVector<QPair<qint64, QString>>* pLrc = m_model->getLyricLines();
     QString text = pLrc->at(row).second;
     besEditDialog.setText(text);
     if(QDialog::Accepted == besEditDialog.exec())

--- a/BesWidgets/table/FinishLrcTableView.h
+++ b/BesWidgets/table/FinishLrcTableView.h
@@ -20,7 +20,7 @@ public:
     void deleteAllItems();
     void appendItems(const QVector<LyricInfo>& infos);
 
-    void setLyricData(QVector<QPair<quint64, QString>>* pLrcLines);
+    void setLyricData(QVector<QPair<qint64, QString>>* pLrcLines);
 
     QVector<QString> getSelectedLrc();
 

--- a/BottomWidgets/BottomWidget.cpp
+++ b/BottomWidgets/BottomWidget.cpp
@@ -221,21 +221,21 @@ void BottomWidget::stop()
 }
 
 //uncalled
-void BottomWidget::seek(quint64 pos)
+void BottomWidget::seek(qint64 pos)
 {
      if(musicPlayer->state() != MusicPlayer::StoppedState )
          musicPlayer->seek(pos);
 }
 
 //uncalled
-void BottomWidget::seekForward(quint64 step)
+void BottomWidget::seekForward(qint64 step)
 {
     if(musicPlayer->state() != MusicPlayer::StoppedState )
         musicPlayer->forwordSeek(step);
 }
 
-//middleWidget->pageMain->subPageMaking,SIGNAL(onSeekBackward(quint64)) emitted
-void BottomWidget::seekBackward(quint64 step)
+//middleWidget->pageMain->subPageMaking,SIGNAL(onSeekBackward(qint64)) emitted
+void BottomWidget::seekBackward(qint64 step)
 {
     if(musicPlayer->state() != MusicPlayer::StoppedState )
         musicPlayer->backwardSeek(step);
@@ -332,7 +332,7 @@ void BottomWidget::onSliderSongReleased()
 {
     qDebug()<<"void BottomWidget::onSliderSongReleased() sliderSong->value()="<<sliderSong->value()<<" posAdjust="<<posAdjust;
 
-            musicPlayer->seek(posAdjust);
+    musicPlayer->seek(posAdjust);
 }
 
 void BottomWidget::onSliderSongClickNotOnHandle(int position)

--- a/BottomWidgets/BottomWidget.h
+++ b/BottomWidgets/BottomWidget.h
@@ -28,9 +28,9 @@ public slots:
     void autoPlayOrPause();             //自动判断播放还是暂停
     void stop();                        //【特别注意：本程序的播放器不是线程安全的，在stop()中的循环等待播放线程结束操作，
                                         // 可能会由于别处同时 调用 stop(),play() 而卡死】
-    void seek(quint64 pos);             //毫秒时间
-    void seekForward(quint64 step);
-    void seekBackward(quint64 step);
+    void seek(qint64 pos);              //毫秒时间
+    void seekForward(qint64 step);
+    void seekBackward(qint64 step);
 
 
     void enterMakingMode();     //进入制作模式
@@ -94,7 +94,7 @@ public:
 private:
 
     bool AdjustingPos;
-    quint64 posAdjust;
+    qint64 posAdjust;
 };
 
 #endif // BOTTOMWIDGET_H

--- a/Entities/LyricMaker.cpp
+++ b/Entities/LyricMaker.cpp
@@ -240,7 +240,7 @@ bool LyricMaker::updateCurrentLineText(QString& line)
 }
 
 //标记当前行为 time
-bool LyricMaker::markCurrentRawLine(quint64 time)
+bool LyricMaker::markCurrentRawLine(qint64 time)
 {
     // warning: comparison of integers of different sign
     if(time < insertOffsetTime){
@@ -248,7 +248,7 @@ bool LyricMaker::markCurrentRawLine(quint64 time)
     }else{
         time -= insertOffsetTime;
     }
-    lrcLines.push_back(QPair<quint64, QString>(time,rawLines[rawCurrent]));
+    lrcLines.push_back(QPair<qint64, QString>(time,rawLines[rawCurrent]));
 
     rawCurrent++;
     lrcNext++;
@@ -257,7 +257,7 @@ bool LyricMaker::markCurrentRawLine(quint64 time)
 }
 
 //标记时间为 time 的空行
-bool LyricMaker::markEmptyLine(quint64 time)
+bool LyricMaker::markEmptyLine(qint64 time)
 {
     //只有当lrc 歌词为空，或者不为空时最后一个元素的内容不为空时，才插入一个空的时间行
     if(lrcLines.isEmpty() || lrcLines.last().second != "")
@@ -268,7 +268,7 @@ bool LyricMaker::markEmptyLine(quint64 time)
         }else{
             time -= insertOffsetTime;
         }
-        lrcLines.push_back(QPair<quint64, QString>(time,""));
+        lrcLines.push_back(QPair<qint64, QString>(time,""));
         lrcNext++;
     }
 
@@ -276,7 +276,7 @@ bool LyricMaker::markEmptyLine(quint64 time)
 }
 
 //回退到 time
-bool LyricMaker::stepBackToTime(quint64 time)
+bool LyricMaker::stepBackToTime(qint64 time)
 {
     //从下标为 0 开始遍历到 lrcNext, 知道找到 比 time 大的，其下标即为跳转后下标
     for(uint i = 0; i< lrcNext; i++)
@@ -317,7 +317,7 @@ bool LyricMaker::stepBackToTime(quint64 time)
 }
 
 //获得上一行LRC歌词的时间，没有上一行时返回-1
-int LyricMaker::getLastLrcLineTime()
+qint64 LyricMaker::getLastLrcLineTime()
 {
     if(!hasPreLrcLine())
         return -1;
@@ -332,7 +332,8 @@ void LyricMaker::finishMaking()
 
     for(auto& line:lrcLines)
     {
-        quint64 time = line.first;
+        qint64 time = line.first;
+
         int ms = time % 1000;
         time = time/1000;
         int s = time % 60;
@@ -353,13 +354,13 @@ bool LyricMaker::isResultLrcEmpty()
 }
 
 
-void LyricMaker::getLyricData(QVector<QString>& _rawLines, QVector<QPair<quint64, QString>>& _lrcLines)
+void LyricMaker::getLyricData(QVector<QString>& _rawLines, QVector<QPair<qint64, QString>>& _lrcLines)
 {
     _rawLines = rawLines;
     _lrcLines = lrcLines;
 }
 
-void LyricMaker::updateLyricData(QVector<QString>& _rawLines, QVector<QPair<quint64, QString>>& _lrcLines)
+void LyricMaker::updateLyricData(QVector<QString>& _rawLines, QVector<QPair<qint64, QString>>& _lrcLines)
 {
     isLyricChanged = true;                  //标记歌词已经发生改变
     rawLines = _rawLines;

--- a/Entities/LyricMaker.h
+++ b/Entities/LyricMaker.h
@@ -19,8 +19,8 @@ public:
     bool saveLyrc(QString savePath);
     bool saveToRawLyric();
 
-    void getLyricData(QVector<QString>& _rawLines, QVector<QPair<quint64, QString>>& _lrcLines);
-    void updateLyricData(QVector<QString>& _rawLines, QVector<QPair<quint64, QString>>& _lrcLines);
+    void getLyricData(QVector<QString>& _rawLines, QVector<QPair<qint64, QString>>& _lrcLines);
+    void updateLyricData(QVector<QString>& _rawLines, QVector<QPair<qint64, QString>>& _lrcLines);
 
     bool isLyricModified(){return isLyricChanged; }
     QString getRawLyricPath(){return rawLyricPath; }
@@ -45,28 +45,28 @@ public slots:
     bool getNextRawLineText(QString& line);        //当前行为最后一行时，将返回 false
     bool getNNextRawLineText(QString& line);       //当前行为最后二行时，将返回 false
 
-    bool updateCurrentLineText(QString& line);      //更新当前行的歌词内容
+    bool updateCurrentLineText(QString& line);     //更新当前行的歌词内容
 
-    bool markCurrentRawLine(quint64 time);         //标记当前行为 time
-    bool markEmptyLine(quint64 time);              //标记时间为 time 的空行
-    bool stepBackToTime(quint64 time);             //回退到 time
+    bool markCurrentRawLine(qint64 time);          //标记当前行为 time
+    bool markEmptyLine(qint64 time);               //标记时间为 time 的空行
+    bool stepBackToTime(qint64 time);              //回退到 time
 
-    int getLastLrcLineTime();                       //获得上一行LRC歌词的时间，没有上一行时返回-1
+    qint64 getLastLrcLineTime();                   //获得上一行LRC歌词的时间，没有上一行时返回-1
 
-    void finishMaking();                            //结束制作
-    bool isResultLrcEmpty();                        //制作结束的lrc是否为空
+    void finishMaking();                           //结束制作
+    bool isResultLrcEmpty();                       //制作结束的lrc是否为空
 
 
 private:
     QVector<QString> rawLines;                          //原始歌词
-    QVector<QPair<quint64, QString>> lrcLines;          //lrc歌词
+    QVector<QPair<qint64, QString>> lrcLines;           //lrc歌词
 
     uint rawCurrent;                                    //原始歌词当前下标
     uint lrcNext;                                       //lrc歌词当前的下一个下标
 
     QString lrcContent;                                 //最终得到的lrc歌词内容
 
-    int insertOffsetTime;                           //插入歌词时提前偏移的时间值
+    int insertOffsetTime;                               //插入歌词时提前偏移的时间值
 
     bool isLyricChanged;                                //标记歌词是否发生改变过
     QString rawLyricPath;                               //源歌词路径

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -281,7 +281,7 @@ void PlayThread::setVolume(int value)
 	m_MS.volume = (uint8_t)value;
 }
 
-int PlayThread::getMsDuration()				//获得毫秒为度量的总长度
+qint64 PlayThread::getMsDuration()				//获得毫秒为度量的总长度
 {
 	if (pFormatCtx == nullptr || !bIsDeviceInit)
 		return 0;
@@ -290,7 +290,7 @@ int PlayThread::getMsDuration()				//获得毫秒为度量的总长度
 }
 
 
-qint64  PlayThread::getCurrentTime() 
+qint64 PlayThread::getCurrentTime()
 { 
 	return m_MS.audio_clock; 
 }
@@ -313,7 +313,7 @@ AudioGenStatus PlayThread::getAGStatus()
 }
 
 
-void  PlayThread::seekToPos(quint64 pos)
+void  PlayThread::seekToPos(qint64 pos)
 {
 	millisecondToSeek = pos; 
 	AGStatus = AGS_SEEK;
@@ -885,13 +885,13 @@ void MusicPlayer::stop()
 }
 
 //跳到时间点播放（单位 毫秒）
-void MusicPlayer::seek(quint64 pos)
+void MusicPlayer::seek(qint64 pos)
 {
     if(state() == StoppedState)
         return;
 
     //先获得总长
-    quint64 total = duration();
+    qint64 total = duration();
     if(pos > total)
     {
         pos = total;
@@ -901,13 +901,13 @@ void MusicPlayer::seek(quint64 pos)
 }
 
 //往后跳（单位 毫秒）
-void MusicPlayer::forwordSeek(quint64 step)
+void MusicPlayer::forwordSeek(qint64 step)
 {
     seek(m_position + step);
 }
 
 //往回跳（单位 毫秒）
-void MusicPlayer::backwardSeek(quint64 step)
+void MusicPlayer::backwardSeek(qint64 step)
 {
     seek(step > m_position ? 0: m_position - step);
 }
@@ -932,7 +932,7 @@ int MusicPlayer::getVolume()
 }
 
 //获得当总时长（单位 毫秒）
-quint64 MusicPlayer::duration()
+qint64 MusicPlayer::duration()
 {
 	return playThread->getMsDuration();
 }

--- a/Entities/MusicPlayer/musicPlayer.h
+++ b/Entities/MusicPlayer/musicPlayer.h
@@ -126,14 +126,14 @@ public:
 	int getVolume();
 	void setVolume(int value);
 
-	int getMsDuration();//获得毫秒为度量的总长度	
+    qint64 getMsDuration();//获得毫秒为度量的总长度
 	qint64 getCurrentTime(); //获得当前毫秒时间
 
 	bool getIsDeviceInit();//实现互斥访问 isDeviceInit 的接口
 
 	void setMusicPath(QString path);
 
-	void seekToPos(quint64 pos);
+    void seekToPos(qint64 pos);
 
 signals:
     void audioLoadedsuccessfully(); //每次音频成功被加载
@@ -222,9 +222,9 @@ private:
 
     AudioGenStatus AGStatus;            //音频产生方式状态
     bool bIsDeviceInit;                 //设备是否已经初始化
-    uint64_t millisecondToSeek;         //定位的 毫秒数）
+    qint64 millisecondToSeek;           //定位的 毫秒数）
 
-	QMutex AGSStatusMutex;				//保证	AGSStatus 状态 某些访问操作 的原子性
+    QMutex AGSStatusMutex;              //保证 AGSStatus 状态 某些访问操作 的原子性
 };
 
 
@@ -274,9 +274,9 @@ signals:
     //      emit errorOccur(6,QString(tr("无法初始化播放设备模块 SDL - %s.")).arg(errorString));
     //      emit errorOccur(7,tr("播放设备模块 SDL 无法打开指定音频数据"));
 
-	void sig_playThreadFinished();	//播放线程完全停止退出
+    void sig_playThreadFinished();	 //播放线程完全停止退出
 
-    void albumFound(QString);       //发现信息
+    void albumFound(QString);        //发现信息
     void artistFound(QString);
     void titleFound(QString);
     void pictureFound(QPixmap);
@@ -288,13 +288,13 @@ public slots:
     void play();
     void pause();
     void stop();
-    void seek(quint64 pos);          //跳到时间点播放（单位 毫秒）
-    void forwordSeek(quint64 step);  //往后跳（单位 毫秒）
-    void backwardSeek(quint64 step); //往回跳（单位 毫秒）
+    void seek(qint64 pos);           //跳到时间点播放（单位 毫秒）
+    void forwordSeek(qint64 step);   //往后跳（单位 毫秒）
+    void backwardSeek(qint64 step);  //往回跳（单位 毫秒）
 
-    void setVolume(int volume);  //音量大小范围 0-128
+    void setVolume(int volume);      //音量大小范围 0-128
     int getVolume();
-    quint64 duration();  //获得当总时长（单位 毫秒）
+    qint64 duration();  //获得当总时长（单位 毫秒）
     qint64 position();  //获得当总位置（单位 毫秒）
 
     Status state();

--- a/MiddleWidgets/LyricEditorBox.cpp
+++ b/MiddleWidgets/LyricEditorBox.cpp
@@ -161,7 +161,7 @@ bool LyricEditorBox::isResultOK()
 }
 
 
-void LyricEditorBox::setLyricData(const QVector<QString>& _rawLines, const QVector<QPair<quint64, QString>>& _lrcLines)
+void LyricEditorBox::setLyricData(const QVector<QString>& _rawLines, const QVector<QPair<qint64, QString>>& _lrcLines)
 {
     rawLines = _rawLines;
     lrcLines = _lrcLines;
@@ -189,7 +189,7 @@ void LyricEditorBox::setLyricData(const QVector<QString>& _rawLines, const QVect
 }
 
 
-void LyricEditorBox::getLyricData(QVector<QString>& _rawLines, QVector<QPair<quint64, QString>>& _lrcLines)
+void LyricEditorBox::getLyricData(QVector<QString>& _rawLines, QVector<QPair<qint64, QString>>& _lrcLines)
 {
     //重新收集原歌词
     _rawLines.clear();

--- a/MiddleWidgets/LyricEditorBox.h
+++ b/MiddleWidgets/LyricEditorBox.h
@@ -25,8 +25,8 @@ public:
 
     bool isResultOK();
 
-    void setLyricData(const QVector<QString>& _rawLines, const QVector<QPair<quint64, QString>>& _lrcLines);
-    void getLyricData(QVector<QString>& _rawLines, QVector<QPair<quint64, QString>>& _lrcLines);
+    void setLyricData(const QVector<QString>& _rawLines, const QVector<QPair<qint64, QString>>& _lrcLines);
+    void getLyricData(QVector<QString>& _rawLines, QVector<QPair<qint64, QString>>& _lrcLines);
 public slots:
 
     void onCopySelected();
@@ -35,7 +35,7 @@ public slots:
 private:
     QVector<QString> lineSelected;
     QVector<QString> rawLines;                          //原始歌词
-    QVector<QPair<quint64, QString>> lrcLines;          //lrc歌词
+    QVector<QPair<qint64, QString>> lrcLines;           //lrc歌词
 
 private:
     QWidget* widgetMessageBoxContainer;

--- a/MiddleWidgets/SubPageMaking.cpp
+++ b/MiddleWidgets/SubPageMaking.cpp
@@ -506,7 +506,7 @@ void SubPageMaking::backBy5Second()
 {
     emit onSeekBackward(5000);
 
-    quint64 to = 0;
+    qint64 to = 0;
     if(curAudioPos > 5000)
         to = curAudioPos - 5000;
 
@@ -521,9 +521,9 @@ void SubPageMaking::backOneLine()
     if(!lyricMaker.hasPreLrcLine())
         return;
 
-    int time = lyricMaker.getLastLrcLineTime();
+    qint64 time = lyricMaker.getLastLrcLineTime();
 
-    int back = curAudioPos-time;
+    qint64 back = curAudioPos-time;
     if(back < 0)
         back = 0;
 
@@ -810,7 +810,7 @@ void SubPageMaking::remaking()
     }
 }
 
-void SubPageMaking::updatePos(int pos)
+void SubPageMaking::updatePos(qint64 pos)
 {
 	if (isMaking)
 	{
@@ -870,7 +870,7 @@ void SubPageMaking::onEditBatchLyric()
     LyricEditorBox* lyricEditor = new LyricEditorBox(nullptr);
 
     QVector<QString>rawLines;
-    QVector<QPair<quint64, QString>> lrcLines;
+    QVector<QPair<qint64, QString>> lrcLines;
     lyricMaker.getLyricData(rawLines,lrcLines);
     lyricEditor->setLyricData(rawLines,lrcLines);
 

--- a/MiddleWidgets/SubPageMaking.h
+++ b/MiddleWidgets/SubPageMaking.h
@@ -38,7 +38,7 @@ private:
 signals:
     void onReloadMusic(QString musicPath);
     void onStartMaking();
-    void onSeekBackward(quint64);           //回退指定毫秒时间
+    void onSeekBackward(qint64);           //回退指定毫秒时间
     void onPlayOrPauseMusic();
     void onStopMusic();
 
@@ -62,7 +62,7 @@ public slots:
     void previewResult();   //点击了预览效果
     void openResult();      //打开生成文件
 
-    void updatePos(int);
+    void updatePos(qint64);
 
     void onGuessNcmInfo();    //猜测ncm文件的歌曲名和歌词
 	void onGuessLyricInfo();  //猜测歌词信息
@@ -93,7 +93,7 @@ private:
     QString         pathOutputDir;
 
     LyricMaker      lyricMaker;
-    int             curAudioPos;        //当前歌曲播放到的位置
+    qint64          curAudioPos;        //当前歌曲播放到的位置
 
     bool            pathLoaded;         //标记路径是否被成功加载
     QString         pathMusicLoaded;    //当前被载入的音乐


### PR DESCRIPTION
1、为了消除 MusicPlayer::backwardSeek(quint64 step) 中有/无符号数不匹配的 warning , 调整使用的类型
2、参考 ffmpeg 代码，时间都是使用 int64_t 所以决定程序中所有 quint64 改为 qint64