### PR TITLE
使默认目录更改立刻生效

### DIFF
--- a/MiddleWidgets/MiddleWidget.cpp
+++ b/MiddleWidgets/MiddleWidget.cpp
@@ -56,7 +56,15 @@ void MiddleWidget::initConnection()
     connect(&animationSettingExtend, &QPropertyAnimation::finished, this, &MiddleWidget::geometryAnimationFinish);
 
     connect(pageMain->subPageMaking, &SubPageMaking::sig_addToMakingHistory, pageLyricList, &PageLyricList::OnAddToMakingHistory);
-   }
+
+    //默认路径发生改变
+    connect(pageSetting->settingWidget->settingScrollPanel, &SuScrollPanel::sig_defaultPathOutputChanged,
+            pageMain->subPageMaking, &SubPageMaking::OnDefaultPathOutputChanged);
+    connect(pageSetting->settingWidget->settingScrollPanel, &SuScrollPanel::sig_defaultPathOutputChanged,
+            pageMain->subPageDownloadLyric, &SubPageDownloadLyric::OnDefaultPathOutputChanged);
+    connect(pageSetting->settingWidget->settingScrollPanel, &SuScrollPanel::sig_defaultPathLyricChanged,
+            pageMain->subPageDownloadLyric, &SubPageDownloadLyric::OnDefaultPathLyricChanged);
+}
 
 
 void MiddleWidget::initAnimation()

--- a/MiddleWidgets/SettingWidget/SettingScrollPanel.cpp
+++ b/MiddleWidgets/SettingWidget/SettingScrollPanel.cpp
@@ -39,6 +39,14 @@ QVector<ISettingUnit *> &SuScrollPanel::getSettingUnits()
         settings.push_back(suUpgrade);
         settings.push_back(suSoftware);
         settings.push_back(suDonation);
+
+        //连接需要发出信号的控件
+        connect((SuDefaultPath*)suDefaultPath, &SuDefaultPath::sig_defaultPathLyricChanged, [=](QString path){
+            emit sig_defaultPathLyricChanged(path);
+        });
+        connect((SuDefaultPath*)suDefaultPath, &SuDefaultPath::sig_defaultPathOutputChanged, [=](QString path){
+            emit sig_defaultPathOutputChanged(path);
+        });
     }
 
     return settings;

--- a/MiddleWidgets/SettingWidget/SettingScrollPanel.h
+++ b/MiddleWidgets/SettingWidget/SettingScrollPanel.h
@@ -31,6 +31,9 @@ public slots:
 signals:
     void sig_scrollPosChanged(int pos, int pageStep, int nScrollMax);//在滚动条位置发生变化时，发出当前的位置
 
+    //默认路径发生改变需要更新相关控件
+    void sig_defaultPathLyricChanged(QString path);
+    void sig_defaultPathOutputChanged(QString path);
 
 private:
     void initEntity();

--- a/MiddleWidgets/SettingWidget/SuDefaultPath.cpp
+++ b/MiddleWidgets/SettingWidget/SuDefaultPath.cpp
@@ -145,6 +145,11 @@ QWidget *SuDefaultPath::getUnitWidget(QWidget *parent)
                 labelDefaultPathLyric->setText(backup);
                 BesMessageBox::information(tr("提示"),tr("保存失败，可能是程序没有写权限"));
             }
+            else
+            {
+                //“下载歌词->原歌词” 页面下的 edit 控件需要立刻生效使用新的路径
+                emit sig_defaultPathLyricChanged(dir);
+            }
         }
     });
 
@@ -165,6 +170,12 @@ QWidget *SuDefaultPath::getUnitWidget(QWidget *parent)
                 SettingManager::GetInstance().data().defaultOutputPath = backup;
                 labelDefaultPathOutput->setText(backup);
                 BesMessageBox::information(tr("提示"),tr("保存失败，可能是程序没有写权限"));
+            }
+            else
+            {
+                //“制作歌词” 页面下的输出目录 edit 控件 以及
+                //“下载歌词->LRC歌词” 页面下的 edit 控件 需要立刻生效使用新的路径
+                emit sig_defaultPathOutputChanged(dir);
             }
         }
     });

--- a/MiddleWidgets/SettingWidget/SuDefaultPath.h
+++ b/MiddleWidgets/SettingWidget/SuDefaultPath.h
@@ -9,10 +9,15 @@
 
 class SuDefaultPath: public ISettingUnit
 {
+    Q_OBJECT
 public:
     virtual QString getName() override;
     virtual int getUnitHeight() override;
     virtual QWidget* getUnitWidget(QWidget* parent) override;
+
+signals:
+    void sig_defaultPathLyricChanged(QString path);
+    void sig_defaultPathOutputChanged(QString path);
 
 public:
     QWidget* SettingUnitContainer;

--- a/MiddleWidgets/SubPageDownloadLyric.cpp
+++ b/MiddleWidgets/SubPageDownloadLyric.cpp
@@ -610,6 +610,16 @@ void SubPageDownloadLyric::OnSaveLrcLyric()
     }
 }
 
+void SubPageDownloadLyric::OnDefaultPathLyricChanged(QString path)
+{
+    editRawLyricPanelSavePath->setText(SettingManager::GetInstance().data().defaultLyricPath); //普通歌词文件的存放目录
+}
+
+void SubPageDownloadLyric::OnDefaultPathOutputChanged(QString path)
+{
+    editLrcLyricPanelSavePath->setText(SettingManager::GetInstance().data().defaultOutputPath); //LRC 文件的存放目录
+}
+
 void SubPageDownloadLyric::searchLyricDirectly(const QString& artists, const QString& song)
 {
     editSearchLyricSong->setText(song);

--- a/MiddleWidgets/SubPageDownloadLyric.h
+++ b/MiddleWidgets/SubPageDownloadLyric.h
@@ -42,6 +42,10 @@ public slots:
     void OnSaveRawLyric();
     void OnSaveLrcLyric();
 
+    //默认路径发生改变
+    void OnDefaultPathLyricChanged(QString path);
+    void OnDefaultPathOutputChanged(QString path);
+
 public:
     void searchLyricDirectly(const QString& artists, const QString& song);
 

--- a/MiddleWidgets/SubPageMaking.cpp
+++ b/MiddleWidgets/SubPageMaking.cpp
@@ -890,6 +890,11 @@ void SubPageMaking::onEditBatchLyric()
     isBatchEditing = false;
 }
 
+//默认输出路径发生改变
+void SubPageMaking::OnDefaultPathOutputChanged(QString path)
+{
+    editSelectOutputDir->setText(SettingManager::GetInstance().data().defaultOutputPath); //LRC 歌词存放目录
+}
 
 void SubPageMaking::selectMusicPath(const QString& musicPath)
 {

--- a/MiddleWidgets/SubPageMaking.h
+++ b/MiddleWidgets/SubPageMaking.h
@@ -58,18 +58,21 @@ public slots:
     void loadCurrentPath();
     void startMaking();
     void remaking();
-    void finishMaking();    //结束制作
-    void previewResult();   //点击了预览效果
-    void openResult();      //打开生成文件
+    void finishMaking();              //结束制作
+    void previewResult();             //点击了预览效果
+    void openResult();                //打开生成文件
 
     void updatePos(qint64);
 
-    void onGuessNcmInfo();    //猜测ncm文件的歌曲名和歌词
-	void onGuessLyricInfo();  //猜测歌词信息
+    void onGuessNcmInfo();            //猜测ncm文件的歌曲名和歌词
+    void onGuessLyricInfo();          //猜测歌词信息
 
-    void onEditCurrentRawLyric(); //直接打开文件编辑当前原歌词
-    void onEditCurrentLine();     //编辑当前行
-    void onEditBatchLyric();      //批量编辑
+    void onEditCurrentRawLyric();     //直接打开文件编辑当前原歌词
+    void onEditCurrentLine();         //编辑当前行
+    void onEditBatchLyric();          //批量编辑
+
+    //默认输出路径发生改变
+    void OnDefaultPathOutputChanged(QString path);
 
 public:
     void selectMusicPath(const QString& musicPath);


### PR DESCRIPTION
resolves #75

1、默认“歌词目录” 改变，需要立刻同步改变 “下载歌词->原歌词” 页面下的 edit 控件
2、默认“输出目录” 改变，需要立刻同步改变 “制作歌词” 页面下的输出目录 edit 控件
   以及 “下载歌词->LRC歌词” 页面下的 edit 控件