### PR TITLE
使用新的数据文件路径以解决权限问题

### DIFF
--- a/Entities/LyricListManager.cpp
+++ b/Entities/LyricListManager.cpp
@@ -1,4 +1,6 @@
-﻿#include "LyricListManager.h"
+﻿#include <QStandardPaths>
+
+#include "LyricListManager.h"
 #include "BesMessageBox.h"
 
 LyricListManager &LyricListManager::GetInstance()
@@ -304,7 +306,7 @@ bool LyricListManager::parseLyricList(QXmlStreamReader &reader, QVector<LyricLis
 
 QString LyricListManager::MakeSureConfigPathAvailable()
 {
-    QString StrDataDir = QCoreApplication::applicationDirPath() + "/data";
+    QString StrDataDir = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
 
     //如果settings 目录不存在则创建目录
     QDir DataDir(StrDataDir);

--- a/Entities/SettingManager.cpp
+++ b/Entities/SettingManager.cpp
@@ -1,4 +1,6 @@
-﻿#include "SettingManager.h"
+﻿#include <QStandardPaths>
+
+#include "SettingManager.h"
 #include "BesMessageBox.h"
 
 SettingManager &SettingManager::GetInstance()
@@ -111,7 +113,7 @@ SettingData &SettingManager::data()
 
 QString SettingManager::SettingManager::MakeSureBaseDataPathAvailable()
 {
-    QString StrDataDir = QCoreApplication::applicationDirPath() + "/data";
+    QString StrDataDir = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
 
     //如果settings 目录不存在则创建目录
     QDir DataDir(StrDataDir);
@@ -375,7 +377,7 @@ bool SettingManager::parseAll(QXmlStreamReader &reader)
 
 QString SettingManager::MakeSureConfigPathAvailable()
 {
-    QString StrDataDir = QCoreApplication::applicationDirPath() + "/data";
+    QString StrDataDir = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
 
     //如果settings 目录不存在则创建目录
     QDir DataDir(StrDataDir);


### PR DESCRIPTION
Fix #59 .
Fix #88 .

现在使用 [`QStandardPaths`](https://doc.qt.io/qt-5/qstandardpaths.html)`::AppLocalDataLocation` 这个路径，数据文件将会位于如下位置：

| OS | Path |
|:- |:- |
| Windows | `%LOCALAPPDATA%/<APPNAME>` (`C:/Users/<USER>/AppData/Local/<APPNAME>`) |
| macOS | `~/Library/Application Support/<APPNAME>` |
| Linux | `~/.local/share/<APPNAME>` |

<br>

注意，程序关于配置和歌单的存储逻辑仍然有改进的空间。