### PR TITLE
修复文件名称含有特殊字符时保存失败问题

### DIFF
--- a/BesWidgets/table/BesNcmSongTableView.cpp
+++ b/BesWidgets/table/BesNcmSongTableView.cpp
@@ -75,7 +75,7 @@ void BesNcmSongTableView::OnDownloadNcmMusic(SONGINFO songInfo)
     QString localFileName = setting.nameFormatStyle==SONG_ARTIST?
                             songInfo.strSong +" - "+ songInfo.strArtists
                            :songInfo.strArtists +" - "+ songInfo.strSong;
-    localFileName = localFileName.replace(QRegExp("[\\/\\\\\\|\\*\\?<>\\:\"]"), " "); //将文件不允许出现的字符替换为空
+    localFileName = localFileName.replace(QRegExp("[\\/\\\\\\|\\*\\?<>\\:\"]"), "_"); //将文件不允许出现的字符替换为下划线
 
     QString strSavePath = setting.musicDowloadPath + '/' + localFileName + ".mp3";
     QString strTempSavePath = setting.musicDowloadPath + '/' + localFileName + "temp.mp3";
@@ -134,7 +134,7 @@ void BesNcmSongTableView::OnFinishedDownload(QVariant data, DOWNLOAD_FINISH_STAT
                 QString localFileName = setting.nameFormatStyle==SONG_ARTIST?
                                         info.strSong +" - "+ info.strArtists
                                        :info.strArtists +" - "+ info.strSong;
-                localFileName = localFileName.replace(QRegExp("[\\/\\\\\\|\\*\\?<>\\:\"]"), " "); //将文件不允许出现的字符替换为空
+                localFileName = localFileName.replace(QRegExp("[\\/\\\\\\|\\*\\?<>\\:\"]"), "_"); //将文件不允许出现的字符替换为下划线
 
                 QString strSavePath = setting.musicDowloadPath + '/' + localFileName + ".mp3";
                 QString strTempSavePath = setting.musicDowloadPath + '/' + localFileName + "temp.mp3";

--- a/MiddleWidgets/SubPageDownloadLyric.cpp
+++ b/MiddleWidgets/SubPageDownloadLyric.cpp
@@ -509,6 +509,9 @@ void SubPageDownloadLyric::OnSaveRawLyric()
     QString localFileName = setting.nameFormatStyle==SONG_ARTIST?
                             song +" - "+ artist
                            :artist +" - "+ song;
+
+    localFileName = localFileName.replace(QRegExp("[\\/\\\\\\|\\*\\?<>\\:\"]"), "_"); //将文件不允许出现的字符替换为下划线
+
     fileName = editRawLyricPanelSavePath->text() + "/" + localFileName + ".txt";
 
     //提示是否保存到路径
@@ -584,6 +587,9 @@ void SubPageDownloadLyric::OnSaveLrcLyric()
     QString localFileName = setting.nameFormatStyle==SONG_ARTIST?
                             song +" - "+ artist
                            :artist +" - "+ song;
+
+    localFileName = localFileName.replace(QRegExp("[\\/\\\\\\|\\*\\?<>\\:\"]"), "_"); //将文件不允许出现的字符替换为下划线
+
     fileName = editLrcLyricPanelSavePath->text() + "/" + localFileName + ".lrc";
 
     //提示是否保存到路径


### PR DESCRIPTION
修复保存歌曲和歌词时，名称中含有“/”等windows不支持的特殊符号导致的保存失败问题