### PR TITLE
优化不恰当地使用 exit 的代码

### DIFF
--- a/Entities/Thread/ThreadConvertMp3.cpp
+++ b/Entities/Thread/ThreadConvertMp3.cpp
@@ -23,7 +23,9 @@ void ThreadConvertMp3::OnGetEditResultd(bool success, QString path, QString erro
     if(!success)
     {
         BesMessageBox::information(tr("提示"),
-            tr("转换 mp3 时发生错误")+ "\n\n" + tr("出错细节:")+ errorTip + "("+ path +")");
+            tr("转换 mp3 时发生错误")+ "\n\n" + tr("出错细节:")+ errorTip + "\n"+ "("+ path +")");
+
+        doneWithError = true;
     }
 
     oneConvertDone = true;
@@ -69,6 +71,7 @@ void ThreadConvertMp3::run()
         mp3Data.mp3OutputPath = task.targetMp3FilePath;
 
         oneConvertDone = false;
+        doneWithError = false;
 
         if(!mp3Editor->CustomizeMp3(task.sourceMp3FilePath,mp3Data))
             goto directCopy;
@@ -76,9 +79,13 @@ void ThreadConvertMp3::run()
         while(!oneConvertDone)
             msleep(500);
 
-        goto convertEnd;
+        if(doneWithError)
+            goto directCopy;
+        else
+            goto convertEnd;
 
 directCopy:
+        //任何失败的情况，直接复制
         QFile::copy(task.sourceMp3FilePath, task.targetMp3FilePath);
         oneConvertDone = true;
 

--- a/Entities/Thread/ThreadConvertMp3.h
+++ b/Entities/Thread/ThreadConvertMp3.h
@@ -68,8 +68,8 @@ private:
 
     QQueue<ConvertTask> taskQueue;
     Mp3Editor* mp3Editor;
-    bool oneConvertDone;
-
+    bool oneConvertDone = false;    //完成一个转换
+    bool doneWithError = false;     //当前转换结束时是否有转换错误
 };
 
 


### PR DESCRIPTION
1、使用抛异常的方式替代 exit 的错误处理方式
2、优化 ThreadConvertMp3 出错时的处理，在转换失败时恰当恢复文件