### PR TITLE
新的依赖结构

### DIFF
--- a/.qmake_things/.qmake_things.pri
+++ b/.qmake_things/.qmake_things.pri
@@ -1,0 +1,8 @@
+# Dig into qmake.
+
+
+# ------ Common ------
+include(common/.common.pri)
+
+# ------ Dependency configurations ------
+include(dependency/.dependency.pri)

--- a/.qmake_things/common/.common.pri
+++ b/.qmake_things/common/.common.pri
@@ -1,0 +1,5 @@
+# Common
+
+
+include(utilities.pri)
+include(basic_test.pri)

--- a/.qmake_things/common/basic_test.pri
+++ b/.qmake_things/common/basic_test.pri
@@ -1,0 +1,12 @@
+# Basic tests
+
+
+# Distinguish the architectures.
+#   Don't use "QMAKE_HOST.arch" because it reported "x86" when the 64 bit kit enabled. https://bugreports.qt.io/browse/QTBUG-30263
+equals(QT_ARCH, i386) {
+    message("QT_ARCH = x86")
+} else:equals(QT_ARCH, x86_64) {
+    message("QT_ARCH = x64")
+} else {
+    error("Unknown architecture")
+}

--- a/.qmake_things/common/utilities.pri
+++ b/.qmake_things/common/utilities.pri
@@ -1,0 +1,224 @@
+# Common Utilities
+
+
+defineTest(checkArgumentCount) {
+    lessThan(ARGC, 3)|greaterThan(ARGC, 4) {
+        checkArgumentCount('checkArgumentCount', $${ARGC}, 3, 4)
+    }
+
+    function_name = $${1}
+    argc_actual = $${2}
+    argc_expected_minimum = $${3}
+    argc_expected_maximum = $${4}
+
+    isEmpty(function_name)|contains(function_name, "^\s*$") {
+        error("Function \"checkArgumentCount\": the 1st parameter \"function_name\" is empty.")
+    }
+    isEmpty(argc_actual)|contains(argc_actual, "^\s*$") {
+        error("Function \"checkArgumentCount\": the 2rd parameter \"argc_actual\" is empty.")
+    }
+    isEmpty(argc_expected_minimum)|contains(argc_expected_minimum, "^\s*$") {
+        error("Function \"checkArgumentCount\": the 3rd parameter \"argc_expected_minimum\" is empty.")
+    }
+
+    isEmpty(argc_expected_maximum) {
+        argc_expected_maximum = $${argc_expected_minimum}
+    } else {
+        contains(argc_expected_maximum, "^\s*$") {
+            error("Function \"checkArgumentCount\": the 4th parameter \"argc_expected_maximum\" is empty.")
+        }
+    }
+
+    lessThan(argc_expected_maximum, $$eval(argc_expected_minimum)) {
+        temp_variable = $${argc_expected_maximum}
+        argc_expected_maximum = $${argc_expected_minimum}
+        argc_expected_minimum = $${temp_variable}
+        unset(temp_variable)
+    }
+
+    equals(argc_expected_minimum, $$eval(argc_expected_maximum)) {
+        expected_argc_message = "$${argc_expected_maximum} parameter"
+    } else {
+        expected_argc_message = "$${argc_expected_minimum} to $${argc_expected_maximum} parameter"
+    }
+    greaterThan(argc_expected_maximum, 1) {
+        expected_argc_message = "$${expected_argc_message}s"
+    }
+
+    lessThan(argc_actual, $$eval(argc_expected_minimum))|greaterThan(argc_actual, $$eval(argc_expected_maximum)) {
+        error("Function \"$${function_name}\": Expected $${expected_argc_message}, but got $${argc_actual}.")
+    }
+}
+
+
+# Don't use `DEST_DIR`, it may be undefined.
+load(resolve_target)
+TARGET_DIR = $$system_path($$dirname(QMAKE_RESOLVED_TARGET))
+message("TARGET_DIR = $${TARGET_DIR}")
+
+
+defineReplace(getSourcePathQuoted) {
+    checkArgumentCount("getSourcePathQuoted", $${ARGC}, 2)
+
+    base_dir_path = $${1}
+    filename = $${2}
+
+    path = $$system_path($$clean_path($$absolute_path($${filename}, $${base_dir_path})))
+    !exists($${path}) {
+        error("\"$${path}\" is NOT existed.")
+    }
+    return ($$shell_quote($${path}))
+}
+
+
+defineReplace(getTargetPathQuoted) {
+    checkArgumentCount("getTargetPathQuoted", $${ARGC}, 0, 1)
+
+    filename = $${1}
+
+    path = $$system_path($$clean_path($$absolute_path($${filename}, $${TARGET_DIR})))
+    return ($$shell_quote($${path}))
+}
+
+
+defineReplace(getOutputPathQuoted) {
+    checkArgumentCount("getOutputPathQuoted", $${ARGC}, 0, 1)
+
+    filename = $${1}
+
+    path = $$system_path($$clean_path($$absolute_path($${filename}, $${OUT_PWD})))
+    return ($$shell_quote($${path}))
+}
+
+
+# From: $$[QT_INSTALL_PREFIX]/mkspecs/features/qt_app.prf
+#       $$[QT_INSTALL_PREFIX]/mkspecs/features/testcase.prf
+#
+# Why don't you guys make the documents better?
+
+# You need to check the three files "Makefile", "Makefile.Debug" and "Makefile.Release" to try to understand what the following code did.
+
+# ------ Example code ------
+# QMAKE_EXTRA_TARGETS *= this_target this_target_clean
+
+# isEmpty(BUILDS)|build_pass {
+#     this_target.depends = first $${this_target.depends}
+
+#     message("this_target.depends = $${this_target.depends}")
+# } else {
+#     # For exclusive builds, copy dlls only once.
+#     this_target.CONFIG = recursive
+#     this_target.target = this_target_all
+#     this_target.recurse_target = this_target
+
+#     # Substitute targets.
+#     this_target_first.depends = $$eval($$first(BUILDS).target)-this_target
+#     this_target_first.target = this_target
+#     QMAKE_EXTRA_TARGETS *= this_target_first
+
+#     message("this_target_first.depends = $${this_target_first.depends}")
+# }
+# ------ Example code ------
+
+defineTest(makeTargetCalledOnlyOnceAndDependsOnFirst) {
+    checkArgumentCount("makeTargetCalledOnlyOnceAndDependsOnFirst", $${ARGC}, 2)
+
+    this_target = $${1}
+    is_dependent_on_first = $${2}
+
+    QMAKE_EXTRA_TARGETS *= $${this_target}
+
+    isEmpty(BUILDS)|build_pass {
+        equals(is_dependent_on_first, true) {
+            $${this_target}.depends = first $$eval($${this_target}.depends)
+        }
+
+        message("$${this_target}.depends = $$eval($${this_target}.depends)")
+
+        export($${this_target}.depends)
+    } else {
+        # For exclusive builds, copy dlls only once.
+        $${this_target}.CONFIG = recursive
+        $${this_target}.target = $${this_target}_all
+        $${this_target}.recurse_target = $${this_target}
+
+        # Substitute targets.
+        $${this_target}_first.depends = $$eval($$first(BUILDS).target)-$${this_target}
+        $${this_target}_first.target = $${this_target}
+        QMAKE_EXTRA_TARGETS *= $${this_target}_first
+
+        message("$${this_target}_first.depends = $$eval($${this_target}_first.depends)")
+
+        export($${this_target}.CONFIG)
+        export($${this_target}.target)
+        export($${this_target}.recurse_target)
+        export($${this_target}_first.depends)
+        export($${this_target}_first.target)
+    }
+
+    export(QMAKE_EXTRA_TARGETS)
+}
+
+
+defineTest(makeFileDistributionTarget) {
+    !win32 {
+        error("Function \"makeFileDistributionTarget\" currently only supports \"win32\" platform.")
+    }
+
+    checkArgumentCount("makeFileDistributionTarget", $${ARGC}, 3, 4)
+
+    this_target = $${1}
+    source_files_path_list = $${2}
+    target_files_path_list = $${3}
+    target_depends_on_this = $${4}
+
+    build_pass {
+        win32-msvc {
+            $${this_target}.commands = \
+                for %i in ($${source_files_path_list}) do \
+                    $${QMAKE_COPY} %i $$getTargetPathQuoted()
+            $${this_target}_clean.commands = \
+                for %i in ($${target_files_path_list}) do \
+                    $${QMAKE_DEL_FILE} %i
+        }
+        win32-g++ {
+            $${this_target}.commands = \
+                for i in $${source_files_path_list} ; do \
+                    $${QMAKE_COPY} --verbose \$\$i $$getTargetPathQuoted() ; \
+                done
+            $${this_target}_clean.commands = \
+                for i in $${target_files_path_list} ; do \
+                    $${QMAKE_DEL_FILE} --verbose \$\$i ; \
+                done
+        }
+
+        DISTCLEAN_DEPS *= $${this_target}_clean
+
+        message("$${this_target}.commands = $$eval($${this_target}.commands)")
+        message("$${this_target}_clean.commands = $$eval($${this_target}_clean.commands)")
+
+        !isEmpty(target_depends_on_this) {
+            $${target_depends_on_this}.depends *= $${this_target}
+            $${target_depends_on_this}_clean.depends *= $${this_target}_clean
+        }
+    } else {
+        $${this_target}.CONFIG *= recursive
+        $${this_target}_clean.CONFIG *= recursive
+    }
+
+    makeTargetCalledOnlyOnceAndDependsOnFirst($${this_target}, false)
+    makeTargetCalledOnlyOnceAndDependsOnFirst($${this_target}_clean, false)
+
+    export($${this_target}.commands)
+    export($${this_target}_clean.commands)
+    export($${this_target}.CONFIG)
+    export($${this_target}_clean.CONFIG)
+    export($${this_target}.depends)
+    export(DISTCLEAN_DEPS)
+    export(QMAKE_EXTRA_TARGETS)
+
+    !isEmpty(target_depends_on_this) {
+        export($${target_depends_on_this}.depends)
+        export($${target_depends_on_this}_clean.depends)
+    }
+}

--- a/.qmake_things/dependency/.dependency.pri
+++ b/.qmake_things/dependency/.dependency.pri
@@ -1,0 +1,13 @@
+# OS-specific dependency configurations.
+
+
+win32 {
+    include(windows/.windows.pri)
+}
+unix {
+    # The order is key.
+    macx {
+        include(macos/.macos.pri)
+    }
+    include(linux/.linux.pri)
+}

--- a/.qmake_things/dependency/linux/.linux.pri
+++ b/.qmake_things/dependency/linux/.linux.pri
@@ -1,0 +1,15 @@
+# Ubuntu, Manjaro, OpenSUSE, Fedora.
+#   This file is also used in macOS.
+
+
+CONFIG *= link_pkgconfig
+PKGCONFIG *= \
+    libavcodec \
+    libavdevice \
+    libavfilter \
+    libavformat \
+    libavutil \
+    libpostproc \
+    libswresample \
+    libswscale \
+    sdl2

--- a/.qmake_things/dependency/macos/.macos.pri
+++ b/.qmake_things/dependency/macos/.macos.pri
@@ -1,0 +1,32 @@
+# macOS 10.13, 10.14 and 10.15.
+
+
+# Because the path of HomeBrew prefix (that is `/usr/local` by default) may not be included by the environment variable `PATH` in Finder,
+#   qmake will not be able to find "pkg-config" installed by HomeBrew.
+# So, just setting `PKG_CONFIG_PATH` to help "pkg-config" to find "*.pc" files is useless in many cases.
+
+
+# The environment variable `B4X_PKG_CONFIG` is optional.
+#   For `B4X_PKG_CONFIG`: ASCII, no accents, spaces nor symlinks, short path, and points to the binary "pkg-config".
+
+
+B4X_PKG_CONFIG = $$getenv(B4X_PKG_CONFIG)
+
+isEmpty(B4X_PKG_CONFIG) {
+    B4X_PKG_CONFIG = /usr/local/bin/pkg-config # I give you a default value.
+    message("env \"B4X_PKG_CONFIG\" is NOT set, try \"$${B4X_PKG_CONFIG}\".")
+}
+
+contains(B4X_PKG_CONFIG, "^\s*$") {
+    error("\"B4X_PKG_CONFIG\" is empty.")
+}
+
+B4X_PKG_CONFIG = $$system_path($$absolute_path($$clean_path($${B4X_PKG_CONFIG})))
+message("B4X_PKG_CONFIG = $${B4X_PKG_CONFIG}")
+!exists($${B4X_PKG_CONFIG}) {
+    error("\"$${B4X_PKG_CONFIG}\" is NOT existed.")
+}
+
+PKG_CONFIG = $${B4X_PKG_CONFIG}
+
+# More configurations will be done by "Linux_common.pri".

--- a/.qmake_things/dependency/windows/.windows.pri
+++ b/.qmake_things/dependency/windows/.windows.pri
@@ -1,0 +1,105 @@
+# VS 2017 (MSVC++ 14.1, _MSC_VER == 1910, or Visual Studio 2017 version 15.0) and later.
+# Windows SDK 10.0.17763.0 and later.
+
+# Mingw-w64-{ i686 | x86_64 }.
+
+# Learnt from:
+#   https://doc.qt.io/qt-5/qmake-advanced-usage.html#adding-custom-targets
+#   $$[QT_INSTALL_PREFIX]/mkspecs/features/win32/windeployqt.prf
+#   $$[QT_INSTALL_PREFIX]/mkspecs/features/qt_functions.prf
+#   $$[QT_INSTALL_PREFIX]/mkspecs/features/qt_app.prf
+#   $$[QT_INSTALL_PREFIX]/mkspecs/features/testcase.prf
+#   https://doc.qt.io/qt-5/qmake-environment-reference.html
+
+
+# Attention!
+#   Mingw-w64 is not fully supported by us. CQtDeployer may be used as a helper in the future.
+
+
+# The environment variable `B4X_DEP_PATH` is required by Windows MSVC while it is optional for Windows Mingw-w64.
+#   For `B4X_DEP_PATH`: ASCII, no accents, spaces nor symlinks, short path.
+
+
+B4X_DEP_PATH = $$getenv(B4X_DEP_PATH)
+
+isEmpty(B4X_DEP_PATH) {
+    win32-msvc {
+        error("env \"B4X_DEP_PATH\" is NOT set.")
+    }
+    win32-g++ {
+        B4X_DEP_PATH = $$system_path($$[QT_INSTALL_PREFIX]) # I give you a default value.
+        message("env \"B4X_DEP_PATH\" is NOT set, try \"$${B4X_DEP_PATH}\".")
+    }
+}
+
+contains(B4X_DEP_PATH, "^\s*$") {
+    error("\"B4X_DEP_PATH\" is empty.")
+}
+
+B4X_DEP_PATH = $$system_path($$absolute_path($$clean_path($${B4X_DEP_PATH})))
+message("B4X_DEP_PATH = $${B4X_DEP_PATH}")
+!exists($${B4X_DEP_PATH}) {
+    error("\"$${B4X_DEP_PATH}\" is NOT existed.")
+}
+
+
+# ------ Headers and Libs ------
+
+include(header_and_lib/windows_header_and_lib.pri)
+
+win32-msvc {
+    locateHeadersAndLibs($${B4X_DEP_PATH})
+}
+win32-g++ {
+    locateHeadersAndLibs()
+}
+
+# ------ DLLs ------
+
+include(dll/windows_dll.pri)
+
+B4X_DEP_PATH_BIN = $$system_path($${B4X_DEP_PATH}/bin) # For Mingw-w64, `$$[QT_INSTALL_PREFIX]/bin` (or `$$[QT_INSTALL_BINS]`) is our home.
+message("B4X_DEP_PATH_BIN = $${B4X_DEP_PATH_BIN}")
+!exists($${B4X_DEP_PATH_BIN}) {
+    error("\"$${B4X_DEP_PATH_BIN}\" is NOT existed.")
+}
+
+# ------ Custom targets ------
+MAIN_TARGET = deploy_windows_dlls
+
+THIRD_PARTY_LIBRARY_DEPLOYMENT_TARGET = deploy_3rd_party_library_dlls
+WINDEPLOYQT_ENHANCED_TARGET = windeployqt_enhanced
+CRT_DEPLOYMENT_TARGET = deploy_CRT_dlls
+UCRT_DEPLOYMENT_TARGET = deploy_UCRT_dlls
+
+makeTargetCalledOnlyOnceAndDependsOnFirst($${MAIN_TARGET}, true)
+makeTargetCalledOnlyOnceAndDependsOnFirst($${MAIN_TARGET}_clean, false)
+
+# ------ 3rd party DLLs ------
+locateThirdPartyDlls( \
+    $${B4X_DEP_PATH_BIN}, \
+    $${THIRD_PARTY_LIBRARY_DEPLOYMENT_TARGET}, \
+    $${MAIN_TARGET} \
+)
+
+# ------ windeployqt - enhanced ------
+invokeWindeployqtEnhanced( \
+    $${WINDEPLOYQT_ENHANCED_TARGET}, \
+    $${MAIN_TARGET} \
+)
+
+win32-msvc {
+    # ------ MSVC CRT ------
+    locateMsvcCrtDlls( \
+        $$getenv(VCToolsVersion), \
+        $${CRT_DEPLOYMENT_TARGET}, \
+        $${MAIN_TARGET} \
+    )
+
+    # ------ MSVC UCRT ------
+    locateMsvcUcrtDlls( \
+        $$getenv(UCRTVersion), \
+        $${UCRT_DEPLOYMENT_TARGET}, \
+        $${MAIN_TARGET} \
+    )
+}

--- a/.qmake_things/dependency/windows/dll/define/windows_dll_define_3rd-party.pri
+++ b/.qmake_things/dependency/windows/dll/define/windows_dll_define_3rd-party.pri
@@ -1,0 +1,31 @@
+# ------ 3rd party DLL ------
+
+
+FFMPEG_DLLS = \
+    avcodec-58.dll \
+    avdevice-58.dll \
+    avfilter-7.dll \
+    avformat-58.dll \
+    avutil-56.dll \
+    postproc-55.dll \
+    swresample-3.dll \
+    swscale-5.dll
+
+SDL2_DLLS = \
+    SDL2.dll
+
+OPENSSL_X86_DLLS = \
+    libcrypto-1_1.dll \
+    libssl-1_1.dll
+
+OPENSSL_X64_DLLS = \
+    libcrypto-1_1-x64.dll \
+    libssl-1_1-x64.dll
+
+equals(QT_ARCH, i386) {
+    OPENSSL_DLLS = $${OPENSSL_X86_DLLS}
+} else:equals(QT_ARCH, x86_64) {
+    OPENSSL_DLLS = $${OPENSSL_X64_DLLS}
+}
+
+THIRD_PARTY_DLLS = $${FFMPEG_DLLS} $${SDL2_DLLS} $${OPENSSL_DLLS}

--- a/.qmake_things/dependency/windows/dll/define/windows_dll_define_msvc-crt.pri
+++ b/.qmake_things/dependency/windows/dll/define/windows_dll_define_msvc-crt.pri
@@ -1,0 +1,36 @@
+# ------ MSVC CRT ------
+
+
+CRT_DEBUG_DLLS = \
+    concrt140d.dll \
+    msvcp140_1d.dll \
+    msvcp140_2d.dll \
+    msvcp140d.dll \
+    vccorlib140d.dll \
+    vcruntime140d.dll
+
+CRT_RELEASE_DLLS = \
+    concrt140.dll \
+    msvcp140_1.dll \
+    msvcp140_2.dll \
+    msvcp140.dll \
+    vccorlib140.dll \
+    vcruntime140.dll
+
+CRT_v142_DEBUG_DLLS = \
+    msvcp140d_codecvt_ids.dll
+
+CRT_v142_RELEASE_DLLS = \
+    msvcp140_codecvt_ids.dll
+
+CRT_v142_X64_DEBUG_DLLS = \
+    vcruntime140_1d.dll
+
+CRT_v142_X64_RELEASE_DLLS = \
+    vcruntime140_1.dll
+
+equals(QT_ARCH, i386) {}
+else:equals(QT_ARCH, x86_64) {
+    CRT_v142_DEBUG_DLLS *= $${CRT_v142_X64_DEBUG_DLLS}
+    CRT_v142_RELEASE_DLLS *= $${CRT_v142_X64_RELEASE_DLLS}
+}

--- a/.qmake_things/dependency/windows/dll/define/windows_dll_define_msvc-ucrt.pri
+++ b/.qmake_things/dependency/windows/dll/define/windows_dll_define_msvc-ucrt.pri
@@ -1,0 +1,58 @@
+# ------ MSVC UCRT ------
+
+
+UCRT_COMMON_DLLS = \
+    api-ms-win-core-console-l1-1-0.dll \
+    api-ms-win-core-console-l1-2-0.dll \
+    api-ms-win-core-datetime-l1-1-0.dll \
+    api-ms-win-core-debug-l1-1-0.dll \
+    api-ms-win-core-errorhandling-l1-1-0.dll \
+    api-ms-win-core-file-l1-1-0.dll \
+    api-ms-win-core-file-l1-2-0.dll \
+    api-ms-win-core-file-l2-1-0.dll \
+    api-ms-win-core-handle-l1-1-0.dll \
+    api-ms-win-core-heap-l1-1-0.dll \
+    api-ms-win-core-interlocked-l1-1-0.dll \
+    api-ms-win-core-libraryloader-l1-1-0.dll \
+    api-ms-win-core-localization-l1-2-0.dll \
+    api-ms-win-core-memory-l1-1-0.dll \
+    api-ms-win-core-namedpipe-l1-1-0.dll \
+    api-ms-win-core-processenvironment-l1-1-0.dll \
+    api-ms-win-core-processthreads-l1-1-0.dll \
+    api-ms-win-core-processthreads-l1-1-1.dll \
+    api-ms-win-core-profile-l1-1-0.dll \
+    api-ms-win-core-rtlsupport-l1-1-0.dll \
+    api-ms-win-core-string-l1-1-0.dll \
+    api-ms-win-core-synch-l1-1-0.dll \
+    api-ms-win-core-synch-l1-2-0.dll \
+    api-ms-win-core-sysinfo-l1-1-0.dll \
+    api-ms-win-core-timezone-l1-1-0.dll \
+    api-ms-win-core-util-l1-1-0.dll \
+    api-ms-win-crt-conio-l1-1-0.dll \
+    api-ms-win-crt-convert-l1-1-0.dll \
+    api-ms-win-crt-environment-l1-1-0.dll \
+    api-ms-win-crt-filesystem-l1-1-0.dll \
+    api-ms-win-crt-heap-l1-1-0.dll \
+    api-ms-win-crt-locale-l1-1-0.dll \
+    api-ms-win-crt-math-l1-1-0.dll \
+    api-ms-win-crt-multibyte-l1-1-0.dll \
+    api-ms-win-crt-private-l1-1-0.dll \
+    api-ms-win-crt-process-l1-1-0.dll \
+    api-ms-win-crt-runtime-l1-1-0.dll \
+    api-ms-win-crt-stdio-l1-1-0.dll \
+    api-ms-win-crt-string-l1-1-0.dll \
+    api-ms-win-crt-time-l1-1-0.dll \
+    api-ms-win-crt-utility-l1-1-0.dll
+
+UCRT_x86_COMMON_DLLS = \
+    API-MS-Win-core-xstate-l2-1-0.dll
+
+equals(QT_ARCH, i386) {
+    UCRT_COMMON_DLLS *= $${UCRT_x86_COMMON_DLLS}
+}
+
+UCRT_DEBUG_DLLS = \
+    ucrtbased.dll
+
+UCRT_RELEASE_DLLS = \
+    ucrtbase.dll

--- a/.qmake_things/dependency/windows/dll/deploy/windows_dll_deploy_3rd-party.pri
+++ b/.qmake_things/dependency/windows/dll/deploy/windows_dll_deploy_3rd-party.pri
@@ -1,0 +1,27 @@
+# ------ 3rd party DLLs ------
+
+
+include(../define/windows_dll_define_3rd-party.pri)
+
+defineTest(locateThirdPartyDlls) {
+    checkArgumentCount("locateThirdPartyDlls", $${ARGC}, 2, 3)
+
+    dlls_dir_path = $${1}
+    this_target = $${2}
+    target_depends_on_this = $${3}
+
+    for(THIRD_PARTY_DLL, THIRD_PARTY_DLLS) {
+        THIRD_PARTY_DLL_SOURCE_PATHS_QUOTED *= $$getSourcePathQuoted($${dlls_dir_path}, $${THIRD_PARTY_DLL})
+        THIRD_PARTY_DLL_TARGET_PATHS_QUOTED *= $$getTargetPathQuoted($${THIRD_PARTY_DLL})
+    }
+
+    message("THIRD_PARTY_DLL_SOURCE_PATHS_QUOTED = $${THIRD_PARTY_DLL_SOURCE_PATHS_QUOTED}")
+    message("THIRD_PARTY_DLL_TARGET_PATHS_QUOTED = $${THIRD_PARTY_DLL_TARGET_PATHS_QUOTED}")
+
+    makeFileDistributionTarget( \
+        $${this_target}, \
+        $${THIRD_PARTY_DLL_SOURCE_PATHS_QUOTED}, \
+        $${THIRD_PARTY_DLL_TARGET_PATHS_QUOTED}, \
+        $${target_depends_on_this} \
+    )
+}

--- a/.qmake_things/dependency/windows/dll/deploy/windows_dll_deploy_msvc-crt.pri
+++ b/.qmake_things/dependency/windows/dll/deploy/windows_dll_deploy_msvc-crt.pri
@@ -1,0 +1,69 @@
+# ------ MSVC CRT ------
+
+
+include(../define/windows_dll_define_msvc-crt.pri)
+
+defineTest(locateMsvcCrtDlls) {
+    checkArgumentCount("locateMsvcCrtDlls", $${ARGC}, 2, 3)
+
+    VCToolsVersion = $${1}
+    this_target = $${2}
+    target_depends_on_this = $${3}
+
+    isEmpty(VCToolsVersion) {
+        error("Unknown env VCToolsVersion")
+    }
+    !versionAtLeast(VCToolsVersion, 14.1) {
+        error("Your MSVC version ($${VCToolsVersion}) is too old, you should install Visual Studio 2017 or later version.")
+    }
+    lessThan(VCToolsVersion, 14.2) {
+        VC_THREE_NUMBER_VERSION = 141 # MSVC v141 (14.1*)
+    } else:lessThan(VCToolsVersion, 14.3) {
+        VC_THREE_NUMBER_VERSION = 142 # MSVC v142 (14.2*)
+    } else {
+        error("Unknown MSVC version.")
+    }
+
+    message("VCToolsVersion = $${VCToolsVersion}")
+
+    CRT_DEBUG_DIR = $$system_path($$clean_path($$getenv(VCToolsRedistDir)/debug_nonredist/$$getenv(Platform)/Microsoft.VC$${VC_THREE_NUMBER_VERSION}.DebugCRT))
+    CRT_RELEASE_DIR = $$system_path($$clean_path($$getenv(VCToolsRedistDir)/$$getenv(Platform)/Microsoft.VC$${VC_THREE_NUMBER_VERSION}.CRT))
+
+    !exists($${CRT_DEBUG_DIR}) {
+        error("\"$${CRT_DEBUG_DIR}\" is NOT existed.")
+    }
+    !exists($${CRT_RELEASE_DIR}) {
+        error("\"$${CRT_RELEASE_DIR}\" is NOT existed.")
+    }
+
+    message("CRT_DEBUG_DIR = $${CRT_DEBUG_DIR}")
+    message("CRT_RELEASE_DIR = $${CRT_RELEASE_DIR}")
+
+    equals(VC_THREE_NUMBER_VERSION, 142) {
+        CRT_DEBUG_DLLS *= $${CRT_v142_DEBUG_DLLS}
+        CRT_RELEASE_DLLS *= $${CRT_v142_RELEASE_DLLS}
+    }
+
+    CONFIG(debug, debug|release) {
+        CRT_DIR = $${CRT_DEBUG_DIR}
+        CRT_DLLS = $${CRT_DEBUG_DLLS}
+    } else:CONFIG(release, debug|release) {
+        CRT_DIR = $${CRT_RELEASE_DIR}
+        CRT_DLLS = $${CRT_RELEASE_DLLS}
+    }
+
+    for(CRT_DLL, CRT_DLLS) {
+        CRT_DLL_SOURCE_PATHS_QUOTED *= $$getSourcePathQuoted($${CRT_DIR}, $${CRT_DLL})
+        CRT_DLL_TARGET_PATHS_QUOTED *= $$getTargetPathQuoted($${CRT_DLL})
+    }
+
+    message("CRT_DLL_SOURCE_PATHS_QUOTED = $${CRT_DLL_SOURCE_PATHS_QUOTED}")
+    message("CRT_DLL_TARGET_PATHS_QUOTED = $${CRT_DLL_TARGET_PATHS_QUOTED}")
+
+    makeFileDistributionTarget( \
+        $${this_target}, \
+        $${CRT_DLL_SOURCE_PATHS_QUOTED}, \
+        $${CRT_DLL_TARGET_PATHS_QUOTED}, \
+        $${target_depends_on_this} \
+    )
+}

--- a/.qmake_things/dependency/windows/dll/deploy/windows_dll_deploy_msvc-ucrt.pri
+++ b/.qmake_things/dependency/windows/dll/deploy/windows_dll_deploy_msvc-ucrt.pri
@@ -1,0 +1,64 @@
+# ------ MSVC UCRT ------
+
+
+include(../define/windows_dll_define_msvc-ucrt.pri)
+
+defineTest(locateMsvcUcrtDlls) {
+    checkArgumentCount("locateMsvcUcrtDlls", $${ARGC}, 2, 3)
+
+    UCRTVersion = $${1}
+    this_target = $${2}
+    target_depends_on_this = $${3}
+
+    isEmpty(UCRTVersion) {
+        error("Unknown env UCRTVersion")
+    }
+    !versionAtLeast(UCRTVersion, 10.0.17763.0) {
+        error("Your UCRT version ($${UCRTVersion}) is too old, you should install Windows SDK 10.0.17763.0 or later version.")
+    }
+
+    message("UCRTVersion = $${UCRTVersion}")
+
+    UCRT_DEBUG_DIR = $$system_path($$clean_path($$getenv(WindowsSdkDir)/bin/$${UCRTVersion}/$$getenv(Platform)/ucrt))
+    UCRT_RELEASE_DIR = $$system_path($$clean_path($$getenv(WindowsSdkDir)/Redist/$${UCRTVersion}/ucrt/DLLs/$$getenv(Platform)))
+    UCRT_COMMON_DIR = $${UCRT_RELEASE_DIR}
+
+    !exists($${UCRT_DEBUG_DIR}) {
+        error("\"$${UCRT_DEBUG_DIR}\" is NOT existed.")
+    }
+    !exists($${UCRT_RELEASE_DIR}) {
+        error("\"$${UCRT_RELEASE_DIR}\" is NOT existed.")
+    }
+
+    message("UCRT_DEBUG_DIR = $${UCRT_DEBUG_DIR}")
+    message("UCRT_RELEASE_DIR = $${UCRT_RELEASE_DIR}")
+
+    for(UCRT_COMMON_DLL, UCRT_COMMON_DLLS) {
+        UCRT_DLL_SOURCE_PATHS_QUOTED *= $$getSourcePathQuoted($${UCRT_COMMON_DIR}, $${UCRT_COMMON_DLL})
+        UCRT_DLL_TARGET_PATHS_QUOTED *= $$getTargetPathQuoted($${UCRT_COMMON_DLL})
+    }
+
+    # For now, only ucrtbase(d).dll in UCRT_{ DEBUG | RELEASE }_DLLS.
+    CONFIG(debug, debug|release) {
+        UCRT_DIR = $${UCRT_DEBUG_DIR}
+        UCRT_DLLS = $${UCRT_DEBUG_DLLS}
+    } else:CONFIG(release, debug|release) {
+        UCRT_DIR = $${UCRT_RELEASE_DIR}
+        UCRT_DLLS = $${UCRT_RELEASE_DLLS}
+    }
+
+    for(UCRT_DLL, UCRT_DLLS) {
+        UCRT_DLL_SOURCE_PATHS_QUOTED *= $$getSourcePathQuoted($${UCRT_DIR}, $${UCRT_DLL})
+        UCRT_DLL_TARGET_PATHS_QUOTED *= $$getTargetPathQuoted($${UCRT_DLL})
+    }
+
+    message("UCRT_DLL_SOURCE_PATHS_QUOTED = $${UCRT_DLL_SOURCE_PATHS_QUOTED}")
+    message("UCRT_DLL_TARGET_PATHS_QUOTED = $${UCRT_DLL_TARGET_PATHS_QUOTED}")
+
+    makeFileDistributionTarget( \
+        $${this_target}, \
+        $${UCRT_DLL_SOURCE_PATHS_QUOTED}, \
+        $${UCRT_DLL_TARGET_PATHS_QUOTED}, \
+        $${target_depends_on_this} \
+    )
+}

--- a/.qmake_things/dependency/windows/dll/deploy/windows_dll_deploy_windeployqt-enhanced.pri
+++ b/.qmake_things/dependency/windows/dll/deploy/windows_dll_deploy_windeployqt-enhanced.pri
@@ -1,0 +1,80 @@
+# ------ windeployqt - enhanced ------
+
+
+defineTest(invokeWindeployqtEnhanced) {
+    checkArgumentCount("invokeWindeployqtEnhanced", $${ARGC}, 1, 2)
+
+    this_target = $${1}
+    target_depends_on_this = $${2}
+
+    windeployqt {
+        error("\"windeployqt\" in CONFIG is not allowed.")
+    }
+    # From: https://bugreports.qt.io/browse/QTBUG-81982
+    qtPrepareTool(QMAKE_WINDEPLOYQT, windeployqt)
+    build_pass {
+        isEmpty(WINDEPLOYQT_OPTIONS) {
+            win32-msvc{
+                # I don't like vcredist_x**.exe
+                WINDEPLOYQT_OPTIONS = --qmldir $$shell_quote($$system_path($${_PRO_FILE_PWD_})) --no-compiler-runtime
+            }
+            win32-g++ {
+                # We do need libgcc_s_seh-1.dll, libstdc++-6.dll and libwinpthread-1.dll
+                WINDEPLOYQT_OPTIONS = --qmldir $$shell_quote($$system_path($${_PRO_FILE_PWD_})) --compiler-runtime
+            }
+        }
+        WINDEPLOYQT_TARGET = $$getTargetPathQuoted()
+        WINDEPLOYQT_OUTPUT = $$getOutputPathQuoted($$basename(TARGET).windeployqt_enhanced)
+        $${this_target}.commands = $${QMAKE_WINDEPLOYQT} $${WINDEPLOYQT_OPTIONS} --list target $${WINDEPLOYQT_TARGET} > $${WINDEPLOYQT_OUTPUT}
+
+        win32-msvc {
+            $${this_target}_clean.commands = if exist $${WINDEPLOYQT_OUTPUT} \
+                                                for /f \"usebackq delims=\" %i in ($${WINDEPLOYQT_OUTPUT}) do \
+                                                    $${QMAKE_DEL_FILE} \"%~fi\" && $${QMAKE_DEL_DIR} \"%~dpi\" || ver > $${QMAKE_SHELL_NULL_DEVICE}
+        }
+        win32-g++ {
+            $${this_target}_clean.commands = test -e $${WINDEPLOYQT_OUTPUT} && \
+                                                while IFS=\$\$\'\r\n\' read -r filepath; do \
+                                                    $${QMAKE_DEL_FILE} --verbose \"\$\$filepath\"; $${QMAKE_DEL_FILE} --dir --verbose \$\$(dirname \"\$\$filepath\"); \
+                                                done < $${WINDEPLOYQT_OUTPUT}
+
+            # Don't use `rmdir` ($${QMAKE_DEL_DIR}). If the directory does not existing, `rmdir` will return non-zero value and let 'make' fail.
+            #
+            # '\$\$' is used to generate a single '$' in 'make' process (It's a `sh -c` command).
+            #   The process: \$\$ (.prf) -(`qmake`)-> $$ (Makefile) -(`sh -c`)-> $ (shell)
+        }
+
+        DISTCLEAN_DEPS *= $${this_target}_clean
+        QMAKE_DISTCLEAN *= $${WINDEPLOYQT_OUTPUT}
+
+        message("WINDEPLOYQT_OPTIONS = $${WINDEPLOYQT_OPTIONS}")
+        message("WINDEPLOYQT_OUTPUT = $${WINDEPLOYQT_OUTPUT}")
+        message("$${this_target}.commands = $$eval($${this_target}.commands)")
+        message("$${this_target}_clean.commands = $$eval($${this_target}_clean.commands)")
+
+        !isEmpty(target_depends_on_this) {
+            $${target_depends_on_this}.depends *= $${this_target}
+            $${target_depends_on_this}_clean.depends *= $${this_target}_clean
+        }
+    } else {
+        $${this_target}.CONFIG *= recursive
+        $${this_target}_clean.CONFIG *= recursive
+    }
+
+    makeTargetCalledOnlyOnceAndDependsOnFirst($${this_target}, true)
+    makeTargetCalledOnlyOnceAndDependsOnFirst($${this_target}_clean, false)
+
+    export($${this_target}.commands)
+    export($${this_target}_clean.commands)
+    export($${this_target}.CONFIG)
+    export($${this_target}_clean.CONFIG)
+    export($${this_target}.depends)
+    export(DISTCLEAN_DEPS)
+    export(QMAKE_DISTCLEAN)
+    export(QMAKE_EXTRA_TARGETS)
+
+    !isEmpty(target_depends_on_this) {
+        export($${target_depends_on_this}.depends)
+        export($${target_depends_on_this}_clean.depends)
+    }
+}

--- a/.qmake_things/dependency/windows/dll/windows_dll.pri
+++ b/.qmake_things/dependency/windows/dll/windows_dll.pri
@@ -1,0 +1,14 @@
+
+# ------ 3rd party DLLs ------
+include(deploy/windows_dll_deploy_3rd-party.pri)
+
+# ------ windeployqt - enhanced ------
+include(deploy/windows_dll_deploy_windeployqt-enhanced.pri)
+
+win32-msvc {
+    # ------ MSVC CRT ------
+    include(deploy/windows_dll_deploy_msvc-crt.pri)
+    
+    # ------ MSVC UCRT ------
+    include(deploy/windows_dll_deploy_msvc-ucrt.pri)
+}

--- a/.qmake_things/dependency/windows/header_and_lib/windows_header_and_lib.pri
+++ b/.qmake_things/dependency/windows/header_and_lib/windows_header_and_lib.pri
@@ -1,0 +1,63 @@
+# ------ Headers and Libs ------
+
+
+defineTest(locateHeadersAndLibs) {
+    win32-msvc {
+        checkArgumentCount("locateHeadersAndLibs", $${ARGC}, 1)
+
+        base_path = $${1}
+
+        include_path = $$system_path($${base_path}/include)
+        lib_path = $$system_path($${base_path}/lib)
+
+        !exists($${include_path}) {
+            error("\"$${include_path}\" is NOT existed.")
+        }
+
+        !exists($${lib_path}) {
+            error("\"$${lib_path}\" is NOT existed.")
+        }
+
+        INCLUDEPATH *= $${include_path}
+        LIBS *= \
+            -L$${lib_path} \
+            -lavcodec \
+            -lavdevice \
+            -lavfilter \
+            -lavformat \
+            -lavutil \
+            -lpostproc \
+            -lswresample \
+            -lswscale \
+            -lSDL2 \
+            -lSDL2main
+
+        message("INCLUDEPATH = $${INCLUDEPATH}")
+        message("LIBS = $${LIBS}")
+
+        export(INCLUDEPATH)
+        export(LIBS)
+    }
+    win32-g++ {
+        checkArgumentCount("locateHeadersAndLibs", $${ARGC}, 0)
+
+        # pkg-config is needed.
+
+        # include(..\Linux\Linux_common.pri)
+
+        CONFIG *= link_pkgconfig
+        PKGCONFIG *= \
+            libavcodec \
+            libavdevice \
+            libavfilter \
+            libavformat \
+            libavutil \
+            libpostproc \
+            libswresample \
+            libswscale \
+            sdl2
+
+        export(CONFIG)
+        export(PKGCONFIG)
+    }
+}

--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -145,99 +145,18 @@ CONFIG(release, debug|release){
 #屏蔽 msvc 编译器对 rational.h 的 warning: C4819: 该文件包含不能在当前代码页(936)中表示的字符。请将该文件保存为 Unicode 格式以防止数据丢失
 win32-msvc*:QMAKE_CXXFLAGS += /wd"4819"
 
-win32{
-
-#根据开发者自己 ffmpeg 和 sdl 库路径，可对如下路径进行修改，不过建议 库安装在 C:/lib 下，
-#   具体使用步骤，可参看项目： https://github.com/BensonLaur/beslyric-lib
-
-#ffmpeg
-
-FFMPEG_INCLUDE  =   C:/lib/beslyric-lib/win32/ffmpeg_4_0_1/include
-FFMPEG_LIB      =   C:/lib/beslyric-lib/win32/ffmpeg_4_0_1/lib
-
-#sdl
-
-SDL_INCLUDE     =   C:/lib/beslyric-lib/SDL_2_0_3/include
-SDL_LIB         =   C:/lib/beslyric-lib/SDL_2_0_3/lib
-
-
-#other
-#OTHER_INCLUDE   =   C:/lib/beslyric-lib/win32/include
-
-INCLUDEPATH +=  $$FFMPEG_INCLUDE \
-                $$SDL_INCLUDE \
-                $$OTHER_INCLUDE \
-
-LIBS += -L$$FFMPEG_LIB/ -lavcodec\
-        -L$$FFMPEG_LIB/ -lavdevice \
-        -L$$FFMPEG_LIB/ -lavfilter \
-        -L$$FFMPEG_LIB/ -lavutil \
-        -L$$FFMPEG_LIB/ -lavformat \
-        -L$$FFMPEG_LIB/ -lpostproc \
-        -L$$FFMPEG_LIB/ -lswresample \
-        -L$$FFMPEG_LIB/ -lswscale \
-        -L$$FFMPEG_LIB/ -lswresample \
-#        -L$$SDL_LIB/ -lSDL2main  \
-        -L$$SDL_LIB/ -lSDL2
-}
-
 
 unix:!macx{
 
 #消除ffmpeg中对使用旧接口的警告
 QMAKE_CXXFLAGS += -Wno-deprecated-declarations
 
-#根据开发者自己 ffmpeg 和 sdl 库路径，可对如下路径进行修改，不过建议 库安装在 /usr/local/ 下，
-#   具体使用步骤，可参看项目： https://github.com/BensonLaur/beslyric-lib
-
-# ffmpeg
-FFMPEG_INCLUDE  = /usr/local/include
-FFMPEG_LIB      = /usr/local/lib
-
-#sdl
-SDL_INCLUDE     = /usr/local/beslyric-lib/SDL_2_0_3/include
-SDL_LIB         = /usr/local/beslyric-lib/SDL_2_0_3/lib
-
-INCLUDEPATH +=  $$FFMPEG_INCLUDE \
-                $$SDL_INCLUDE \
-
-LIBS += $$FFMPEG_LIB/libavcodec.so      \
-        $$FFMPEG_LIB/libavdevice.so     \
-        $$FFMPEG_LIB/libavfilter.so     \
-        $$FFMPEG_LIB/libavformat.so     \
-        $$FFMPEG_LIB/libavutil.so       \
-        $$FFMPEG_LIB/libswresample.so   \
-        $$FFMPEG_LIB/libswscale.so      \
-        #$$FFMPEG_LIB/libpostproc.so    \
-#        -L$$SDL_LIB/ -lSDL2main        \   #can't be $$PSDL_LIB/ -lSDL2main, must be -L$$PSDL_LIB/ -lSDL2main
-        -L$$SDL_LIB/ -lSDL2
 }
 
+#--------------------------------
 
-macx{
-#根据开发者自己 ffmpeg 和 sdl 库路径，可对如下路径进行修改，不过建议 库安装在 /usr/local/ 下，
-#   具体使用步骤，可参看项目： https://github.com/BensonLaur/beslyic-lib
+# Our qmake code.
 
-# ffmpeg
-FFMPEG_INCLUDE  = /usr/local/include
-FFMPEG_LIB      = /usr/local/lib
+include(.qmake_things/.qmake_things.pri)
 
-#sdl
-SDL_INCLUDE     = /usr/local/include/SDL2
-SDL_LIB         = /usr/local/lib
-
-INCLUDEPATH +=  $$FFMPEG_INCLUDE \
-                $$SDL_INCLUDE \
-
-LIBS += -L$$FFMPEG_LIB/ -lavcodec      \
-        -L$$FFMPEG_LIB/ -lavdevice     \
-        -L$$FFMPEG_LIB/ -lavfilter     \
-        -L$$FFMPEG_LIB/ -lavformat     \
-        -L$$FFMPEG_LIB/ -lavutil       \
-        -L$$FFMPEG_LIB/ -lswresample   \
-        -L$$FFMPEG_LIB/ -lswscale   \
-#        -L$$SDL_LIB/ -lSDL2main        \
-        -L$$SDL_LIB/ -lSDL2
-
-}
-
+#--------------------------------

--- a/Entities/MP3Editor/ffmpegDefine.h
+++ b/Entities/MP3Editor/ffmpegDefine.h
@@ -12,54 +12,38 @@
 
 #define __STDC_CONSTANT_MACROS
 
-#ifdef _WIN32
-//Windows
 extern "C"
 {
-#include "libavcodec/avcodec.h"
-#include "libavformat/avformat.h"
-#include "libswresample/swresample.h"
-#include "libavutil/opt.h"
-#include "libavutil/mem.h"
-#include "libavutil/avstring.h"
-#include "libavutil/intreadwrite.h"
-#include "libavutil/parseutils.h"
-#include "libavutil/pixdesc.h"
-#include "libavutil/eval.h"
-#include "libavutil/fifo.h"
-#include "libavutil/time.h"
-#include "libavutil/timestamp.h"
-#include "libavutil/bprint.h"
-#include "SDL.h"
-}
-
-#include <stdlib.h>  //使用 _sleep();
-
-#else
-//Linux...
-#ifdef __cplusplus
-extern "C"
-{
-#endif
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libswresample/swresample.h>
-#include "libavutil/opt.h"
-#include "libavutil/mem.h"
-#include "libavutil/avstring.h"
-#include "libavutil/intreadwrite.h"
-#include "libavutil/parseutils.h"
-#include "libavutil/pixdesc.h"
-#include "libavutil/eval.h"
-#include "libavutil/fifo.h"
-#include "libavutil/time.h"
-#include "libavutil/timestamp.h"
-#include "libavutil/bprint.h"
-#include "SDL.h"
-#ifdef __cplusplus
-}
-#include <unistd.h>
+#include <libavutil/opt.h>
+#include <libavutil/mem.h>
+#include <libavutil/avstring.h>
+#include <libavutil/intreadwrite.h>
+#include <libavutil/parseutils.h>
+#include <libavutil/pixdesc.h>
+#include <libavutil/eval.h>
+#include <libavutil/fifo.h>
+#include <libavutil/time.h>
+#include <libavutil/timestamp.h>
+#include <libavutil/bprint.h>
+
+#ifdef Q_OS_MAC
+// For SDL2 installed by HomeBrew on macOS
+#include <SDL.h>
+#else
+#include <SDL2/SDL.h>
 #endif
+
+}
+
+#ifdef _WIN32
+//Windows
+#include <stdlib.h>  //使用 _sleep();
+#else
+//Linux...
+#include <unistd.h>
 #endif
 
 

--- a/Entities/MusicPlayer/musicPlayer.h
+++ b/Entities/MusicPlayer/musicPlayer.h
@@ -19,32 +19,27 @@
 
 #define __STDC_CONSTANT_MACROS
 
-#ifdef _WIN32
-//Windows
 extern "C"
 {
-#include "libavcodec/avcodec.h"
-#include "libavformat/avformat.h"
-#include "libswresample/swresample.h"
-#include "SDL.h"
-}
-
-#include <stdlib.h>  //使用 _sleep();
-
-#else
-//Linux...
-#ifdef __cplusplus
-extern "C"
-{
-#endif
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libswresample/swresample.h>
-#include "SDL.h"
-#ifdef __cplusplus
-}
-#include <unistd.h>
+
+#ifdef Q_OS_MAC
+// For SDL2 installed by HomeBrew on macOS
+#include <SDL.h>
+#else
+#include <SDL2/SDL.h>
 #endif
+
+}
+
+#ifdef _WIN32
+//Windows
+#include <stdlib.h>  //使用 _sleep();
+#else
+//Linux...
+#include <unistd.h>
 #endif
 
 #define FLUSH_DATA "FLUSH"

--- a/main.cpp
+++ b/main.cpp
@@ -10,6 +10,13 @@
 
 #include <LyricListManager.h>
 
+#ifdef Q_OS_MAC
+// For SDL2 installed by HomeBrew on macOS
+#include <SDL.h>
+#else
+#include <SDL2/SDL.h>
+#endif
+
 
 void test()
 {


### PR DESCRIPTION
为了正确处理依赖，从现在起需要在一些平台上设置变量：

- macOS: `B4X_PKG_CONFIG`
- Windows: `B4X_DEP_PATH`

一些 64 位平台的文档：

- Linux: https://github.com/BesLyric-for-X/BesLyric-for-X_Conf/tree/linux_x64_3.1.3
- macOS: https://github.com/BesLyric-for-X/BesLyric-for-X_Conf/tree/macos_x64_3.1.3
- Windows Mingw-w64: https://github.com/BesLyric-for-X/BesLyric-for-X_Conf/tree/windows_mingw-w64_x64_3.1.3
- Windows MSVC: https://github.com/BesLyric-for-X/BesLyric-for-X_Conf/tree/windows_msvc_x64_3.1.3

---

注意，之前关于 SDL2main 库文件的修改（ #53 ）并不是错误的。

考虑到要让一种写法尽可能地适配不同的平台，就让 SDL 在 B4X 的`main`方法之前初始化。但这时链接`SDL2main.lib`对于 Windows MSVC 来说就是必要的，因此添加了`-lSDL2main`。

“让一种写法尽可能地适配不同的平台”并不是一个非常充分的理由，但这至少解决了一些与平台有关的兼容性问题。