### PR TITLE
! 新的依赖指令

### DIFF
--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -145,99 +145,81 @@ CONFIG(release, debug|release){
 #屏蔽 msvc 编译器对 rational.h 的 warning: C4819: 该文件包含不能在当前代码页(936)中表示的字符。请将该文件保存为 Unicode 格式以防止数据丢失
 win32-msvc*:QMAKE_CXXFLAGS += /wd"4819"
 
-win32{
+#--------------------------------
 
-#根据开发者自己 ffmpeg 和 sdl 库路径，可对如下路径进行修改，不过建议 库安装在 C:/lib 下，
-#   具体使用步骤，可参看项目： https://github.com/BensonLaur/beslyric-lib
+# Third-party libraries
 
-#ffmpeg
-
-FFMPEG_INCLUDE  =   C:/lib/beslyric-lib/win32/ffmpeg_4_0_1/include
-FFMPEG_LIB      =   C:/lib/beslyric-lib/win32/ffmpeg_4_0_1/lib
-
-#sdl
-
-SDL_INCLUDE     =   C:/lib/beslyric-lib/SDL_2_0_3/include
-SDL_LIB         =   C:/lib/beslyric-lib/SDL_2_0_3/lib
-
-
-#other
-#OTHER_INCLUDE   =   C:/lib/beslyric-lib/win32/include
-
-INCLUDEPATH +=  $$FFMPEG_INCLUDE \
-                $$SDL_INCLUDE \
-                $$OTHER_INCLUDE \
-
-LIBS += -L$$FFMPEG_LIB/ -lavcodec\
-        -L$$FFMPEG_LIB/ -lavdevice \
-        -L$$FFMPEG_LIB/ -lavfilter \
-        -L$$FFMPEG_LIB/ -lavutil \
-        -L$$FFMPEG_LIB/ -lavformat \
-        -L$$FFMPEG_LIB/ -lpostproc \
-        -L$$FFMPEG_LIB/ -lswresample \
-        -L$$FFMPEG_LIB/ -lswscale \
-        -L$$FFMPEG_LIB/ -lswresample \
-#        -L$$SDL_LIB/ -lSDL2main  \
-        -L$$SDL_LIB/ -lSDL2
+win32-gcc {
+    error("MinGW is not fully supported, sorry.")
 }
 
+win32-msvc {
+    B4X_DEP_PATH = $$getenv(B4X_DEP_PATH)
+    isEmpty(B4X_DEP_PATH) {
+        error("env \"B4X_DEP_PATH\" is NOT set.")
+    }
+    contains(B4X_DEP_PATH, "^\s*$") {
+        error("\"B4X_DEP_PATH\" is empty.")
+    }
+    message("env B4X_DEP_PATH = $${B4X_DEP_PATH}")
 
-unix:!macx{
+    dep_base_path = $$system_path($$absolute_path($$clean_path($${B4X_DEP_PATH})))
+    !exists($${dep_base_path}) {
+        error("\"$${dep_base_path}\" does NOT exist.")
+    }
+    message("dep_base_path = $${dep_base_path}")
 
-#消除ffmpeg中对使用旧接口的警告
-QMAKE_CXXFLAGS += -Wno-deprecated-declarations
+    dep_include_path = $$system_path($${dep_base_path}/include)
+    !exists($${dep_include_path}) {
+        error("\"$${dep_include_path}\" does NOT exist.")
+    }
+    message("dep_include_path = $${dep_include_path}")
 
-#根据开发者自己 ffmpeg 和 sdl 库路径，可对如下路径进行修改，不过建议 库安装在 /usr/local/ 下，
-#   具体使用步骤，可参看项目： https://github.com/BensonLaur/beslyric-lib
+    dep_lib_path = $$system_path($${dep_base_path}/lib)
+    !exists($${dep_lib_path}) {
+        error("\"$${dep_lib_path}\" does NOT exist.")
+    }
+    message("dep_lib_path = $${dep_lib_path}")
 
-# ffmpeg
-FFMPEG_INCLUDE  = /usr/local/include
-FFMPEG_LIB      = /usr/local/lib
+    dep_bin_path = $$system_path($${dep_base_path}/bin)
+    !exists($${dep_bin_path}) {
+        error("\"$${dep_bin_path}\" does NOT exist.")
+    }
+    message("dep_bin_path = $${dep_bin_path}")
 
-#sdl
-SDL_INCLUDE     = /usr/local/beslyric-lib/SDL_2_0_3/include
-SDL_LIB         = /usr/local/beslyric-lib/SDL_2_0_3/lib
+    INCLUDEPATH *= $${dep_include_path}
+    LIBS *= \
+        -L$${dep_lib_path} \
+        -lavcodec \
+        -lavdevice \
+        -lavfilter \
+        -lavformat \
+        -lavutil \
+        -lpostproc \
+        -lswresample \
+        -lswscale \
+        -lSDL2 \
+        -lSDL2main
 
-INCLUDEPATH +=  $$FFMPEG_INCLUDE \
-                $$SDL_INCLUDE \
-
-LIBS += $$FFMPEG_LIB/libavcodec.so      \
-        $$FFMPEG_LIB/libavdevice.so     \
-        $$FFMPEG_LIB/libavfilter.so     \
-        $$FFMPEG_LIB/libavformat.so     \
-        $$FFMPEG_LIB/libavutil.so       \
-        $$FFMPEG_LIB/libswresample.so   \
-        $$FFMPEG_LIB/libswscale.so      \
-        #$$FFMPEG_LIB/libpostproc.so    \
-#        -L$$SDL_LIB/ -lSDL2main        \   #can't be $$PSDL_LIB/ -lSDL2main, must be -L$$PSDL_LIB/ -lSDL2main
-        -L$$SDL_LIB/ -lSDL2
+    unset(dep_bin_path)
+    unset(dep_lib_path)
+    unset(dep_include_path)
+    unset(dep_base_path)
+    unset(B4X_DEP_PATH)
 }
 
-
-macx{
-#根据开发者自己 ffmpeg 和 sdl 库路径，可对如下路径进行修改，不过建议 库安装在 /usr/local/ 下，
-#   具体使用步骤，可参看项目： https://github.com/BensonLaur/beslyic-lib
-
-# ffmpeg
-FFMPEG_INCLUDE  = /usr/local/include
-FFMPEG_LIB      = /usr/local/lib
-
-#sdl
-SDL_INCLUDE     = /usr/local/include/SDL2
-SDL_LIB         = /usr/local/lib
-
-INCLUDEPATH +=  $$FFMPEG_INCLUDE \
-                $$SDL_INCLUDE \
-
-LIBS += -L$$FFMPEG_LIB/ -lavcodec      \
-        -L$$FFMPEG_LIB/ -lavdevice     \
-        -L$$FFMPEG_LIB/ -lavfilter     \
-        -L$$FFMPEG_LIB/ -lavformat     \
-        -L$$FFMPEG_LIB/ -lavutil       \
-        -L$$FFMPEG_LIB/ -lswresample   \
-        -L$$FFMPEG_LIB/ -lswscale   \
-#        -L$$SDL_LIB/ -lSDL2main        \
-        -L$$SDL_LIB/ -lSDL2
-
+unix {
+    CONFIG *= link_pkgconfig
+    PKGCONFIG *= \
+        libavcodec \
+        libavdevice \
+        libavfilter \
+        libavformat \
+        libavutil \
+        libpostproc \
+        libswresample \
+        libswscale \
+        sdl2
 }
 
+#--------------------------------

--- a/Entities/MP3Editor/ffmpegDefine.h
+++ b/Entities/MP3Editor/ffmpegDefine.h
@@ -12,31 +12,6 @@
 
 #define __STDC_CONSTANT_MACROS
 
-#ifdef _WIN32
-//Windows
-extern "C"
-{
-#include "libavcodec/avcodec.h"
-#include "libavformat/avformat.h"
-#include "libswresample/swresample.h"
-#include "libavutil/opt.h"
-#include "libavutil/mem.h"
-#include "libavutil/avstring.h"
-#include "libavutil/intreadwrite.h"
-#include "libavutil/parseutils.h"
-#include "libavutil/pixdesc.h"
-#include "libavutil/eval.h"
-#include "libavutil/fifo.h"
-#include "libavutil/time.h"
-#include "libavutil/timestamp.h"
-#include "libavutil/bprint.h"
-#include "SDL.h"
-}
-
-#include <stdlib.h>  //使用 _sleep();
-
-#else
-//Linux...
 #ifdef __cplusplus
 extern "C"
 {
@@ -44,22 +19,35 @@ extern "C"
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libswresample/swresample.h>
-#include "libavutil/opt.h"
-#include "libavutil/mem.h"
-#include "libavutil/avstring.h"
-#include "libavutil/intreadwrite.h"
-#include "libavutil/parseutils.h"
-#include "libavutil/pixdesc.h"
-#include "libavutil/eval.h"
-#include "libavutil/fifo.h"
-#include "libavutil/time.h"
-#include "libavutil/timestamp.h"
-#include "libavutil/bprint.h"
-#include "SDL.h"
-#ifdef __cplusplus
-}
+#include <libavutil/opt.h>
+#include <libavutil/mem.h>
+#include <libavutil/avstring.h>
+#include <libavutil/intreadwrite.h>
+#include <libavutil/parseutils.h>
+#include <libavutil/pixdesc.h>
+#include <libavutil/eval.h>
+#include <libavutil/fifo.h>
+#include <libavutil/time.h>
+#include <libavutil/timestamp.h>
+#include <libavutil/bprint.h>
+
+#ifdef Q_OS_MAC
+// For SDL2 installed by HomeBrew on macOS
+#include <SDL.h>
+#else
+#include <SDL2/SDL.h>
+#endif
+
+#ifdef _WIN32
+//Windows
+#include <stdlib.h>  //使用 _sleep();
+
+#else
+//Linux...
 #include <unistd.h>
 #endif
+#ifdef __cplusplus
+}
 #endif
 
 

--- a/Entities/MusicPlayer/musicPlayer.h
+++ b/Entities/MusicPlayer/musicPlayer.h
@@ -19,20 +19,6 @@
 
 #define __STDC_CONSTANT_MACROS
 
-#ifdef _WIN32
-//Windows
-extern "C"
-{
-#include "libavcodec/avcodec.h"
-#include "libavformat/avformat.h"
-#include "libswresample/swresample.h"
-#include "SDL.h"
-}
-
-#include <stdlib.h>  //使用 _sleep();
-
-#else
-//Linux...
 #ifdef __cplusplus
 extern "C"
 {
@@ -40,11 +26,24 @@ extern "C"
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libswresample/swresample.h>
-#include "SDL.h"
-#ifdef __cplusplus
-}
+
+#ifdef Q_OS_MAC
+// For SDL2 installed by HomeBrew on macOS
+#include <SDL.h>
+#else
+#include <SDL2/SDL.h>
+#endif
+
+#ifdef _WIN32
+//Windows
+#include <stdlib.h>  //使用 _sleep();
+
+#else
+//Linux...
 #include <unistd.h>
 #endif
+#ifdef __cplusplus
+}
 #endif
 
 #define FLUSH_DATA "FLUSH"

--- a/main.cpp
+++ b/main.cpp
@@ -10,6 +10,21 @@
 
 #include <LyricListManager.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+#ifdef Q_OS_WIN
+// On Windows, SDL will do initialization in "SDL_main()" before calling our "main()".
+//   https://stackoverflow.com/questions/11976084/why-sdl-defines-main-macro
+//   http://wiki.libsdl.org/FAQWindows#I_get_.22Undefined_reference_to_.27SDL_main.27.22_...
+//   https://stackoverflow.com/questions/64396979/how-do-i-use-sdl2-in-my-programs-correctly
+//   https://www.libsdl.org/tmp/SDL/VisualC.html
+#include <SDL2/SDL.h>
+#endif
+#ifdef __cplusplus
+}
+#endif
 
 void test()
 {


### PR DESCRIPTION
本 PR 由 #107 裁剪和修改而来。

---

为了正确处理依赖，在 Windows 上使用 MSVC 时需要设置环境变量`B4X_DEP_PATH`。

各个 64 位平台的文档：

- Linux: https://github.com/BesLyric-for-X/BesLyric-for-X_Conf/tree/linux_x64_3.1.3
- macOS: https://github.com/BesLyric-for-X/BesLyric-for-X_Conf/tree/macos_x64_3.1.3_1
- Windows MSVC: https://github.com/BesLyric-for-X/BesLyric-for-X_Conf/tree/windows_msvc_x64_3.1.3_1

---

关于 SDL2main ：

按照 SDL 的文档，在 Windows 平台，要让 SDL 在 B4X 的`main`方法之前初始化，于是将`-lSDL2main`添加回来。

我不明白 #53 为何能够解决当时的问题。看起来既不链接`SDL2main`也不使用 SDL 的`main`做初始化似乎也是可行的。不过，既然官方文档有建议用法，那就照做。

参考资料：
- [c++ - Why SDL defines main macro? - Stack Overflow](https://stackoverflow.com/questions/11976084/why-sdl-defines-main-macro)
- [FAQWindows - SDL Wiki' § I get "Undefined reference to 'SDL_main'" ...](http://wiki.libsdl.org/FAQWindows#I_get_.22Undefined_reference_to_.27SDL_main.27.22_...)
- [c++ - How do I use SDL2 in my programs correctly? - Stack Overflow](https://stackoverflow.com/questions/64396979/how-do-i-use-sdl2-in-my-programs-correctly)
- [Using SDL with Microsoft Visual C++](https://www.libsdl.org/tmp/SDL/VisualC.html)
