### PR TITLE
调整 windows 版本获取更新信息的链接

### DIFF
--- a/Define/Static.h
+++ b/Define/Static.h
@@ -16,7 +16,6 @@ static const QString LINK_SEND_LOGIN = "http://beslyric.320.io/BesBlog/beslyric/
 #ifdef Q_OS_WIN32
 
 static const QString OS_NAME = "windows";
-static const QString  LINK_VERSION_LOG= "http://files.cnblogs.com/files/BensonLaur/versionLog.zip";			//链接，指向版本日志文件
 static const QString  LINK_LAST_VERSION_INFO_OLD= "https://files-cdn.cnblogs.com/files/BensonLaur/lastVersion-windows.zip";	
 static const QString  LINK_LAST_VERSION_INFO = "https://files-cdn.cnblogs.com/files/BensonLaur/lastVersion-windows-new.zip";	//链接，指向最后版本信息的文件
 
@@ -29,7 +28,6 @@ static const QString  LINK_LAST_VERSION_INFO = "https://files-cdn.cnblogs.com/fi
 #ifdef Q_OS_LINUX
 
 static const QString OS_NAME = "linux";
-static const QString  LINK_VERSION_LOG= "http://files.cnblogs.com/files/BensonLaur/versionLog.zip";			//链接，指向版本日志文件
 static const QString  LINK_LAST_VERSION_INFO= "https://files-cdn.cnblogs.com/files/BensonLaur/lastVersion-linux.zip";		//链接，指向最后版本信息的文件
 
 #endif
@@ -38,7 +36,6 @@ static const QString  LINK_LAST_VERSION_INFO= "https://files-cdn.cnblogs.com/fil
 #ifdef Q_OS_MAC
 
 static const QString OS_NAME = "mac";
-static const QString  LINK_VERSION_LOG= "http://files.cnblogs.com/files/BensonLaur/versionLog.zip";			//链接，指向版本日志文件
 static const QString  LINK_LAST_VERSION_INFO= "https://files-cdn.cnblogs.com/files/BensonLaur/lastVersion-mac.zip";		//链接，指向最后版本信息的文件
 
 #endif

--- a/Define/Static.h
+++ b/Define/Static.h
@@ -17,7 +17,11 @@ static const QString LINK_SEND_LOGIN = "http://beslyric.320.io/BesBlog/beslyric/
 
 static const QString OS_NAME = "windows";
 static const QString  LINK_VERSION_LOG= "http://files.cnblogs.com/files/BensonLaur/versionLog.zip";			//链接，指向版本日志文件
-static const QString  LINK_LAST_VERSION_INFO= "https://files-cdn.cnblogs.com/files/BensonLaur/lastVersion-windows.zip";		//链接，指向最后版本信息的文件
+static const QString  LINK_LAST_VERSION_INFO_OLD= "https://files-cdn.cnblogs.com/files/BensonLaur/lastVersion-windows.zip";	
+static const QString  LINK_LAST_VERSION_INFO = "https://files-cdn.cnblogs.com/files/BensonLaur/lastVersion-windows-new.zip";	//链接，指向最后版本信息的文件
+
+//注：关于 LINK_LAST_VERSION_INFO_OLD 和 LINK_LAST_VERSION_INFO
+//从 3.1.3 开始，使用一个新的获取更新信息的链接，已达到让所有旧版本最多能够获取到 3.1.3 版本的更新信息的目的
 
 #endif
 


### PR DESCRIPTION
更新前：
https://files-cdn.cnblogs.com/files/BensonLaur/lastVersion-windows.zip
更新后：
https://files-cdn.cnblogs.com/files/BensonLaur/lastVersion-windows-new.zip

从 3.1.3 开始，使用一个新的获取更新信息的链接，已达到让所有旧版本最多只能够获取到 3.1.3 版本的更新信息的目的