### PR TITLE
输出的时间标签格式由3位小数位调整为2位小数位

### DIFF
--- a/Entities/LyricMaker.cpp
+++ b/Entities/LyricMaker.cpp
@@ -340,7 +340,7 @@ void LyricMaker::finishMaking()
         int m = time/60;
 
         QString timeLabel;
-        timeLabel.sprintf("%.2d:%.2d.%.3d",m, s, ms);
+        timeLabel.sprintf("%.2d:%.2d.%.2d",m, s, ms / 10);
 
         QString oneline = "["+timeLabel+"]"+line.second + "\n";
         lrcContent.append(oneline);


### PR DESCRIPTION
See #115 .