### PR TITLE
不在 Qt 5.12 及更低版本中使用未引入的 QUrlQuery 的列表初始化构造方法

### DIFF
--- a/Entities/ThreadLogin.h
+++ b/Entities/ThreadLogin.h
@@ -86,6 +86,16 @@ protected:
             strIP = "unknown";
 
         //访问链接，服务端负责记录登录信息
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
+        QUrlQuery loginInfoQuery{};
+        loginInfoQuery.addQueryItem("ip", strIP);
+        loginInfoQuery.addQueryItem("version", VERSION_NAME);
+        loginInfoQuery.addQueryItem("vernum", VERSION_NUMBER);
+        loginInfoQuery.addQueryItem("systemArchitecture",
+             "[Build]" + QSysInfo::buildCpuArchitecture()
+             + "[Current]" + QSysInfo::currentCpuArchitecture()
+         );
+#else
         QUrlQuery loginInfoQuery{
             QPair<QString, QString>{"ip", strIP},
             QPair<QString, QString>{"version", VERSION_NAME},
@@ -95,6 +105,7 @@ protected:
                 + "[Current]" + QSysInfo::currentCpuArchitecture()
             }
         };
+#endif
         NetworkAccess::SyncDownloadString(LINK_SEND_LOGIN, tempBuffer, loginInfoQuery, false);
     }
 


### PR DESCRIPTION
Fix 837005372d431e07e4b4f0911469cecc9bff4b15 in #119 .

> ## QUrlQuery::QUrlQuery(std::initializer_list<QPair<QString, QString> > list)
> Constructs a QUrlQuery object from the list of key/value pair.
> 
> This function was introduced in Qt 5.13.
> https://doc.qt.io/qt-5/qurlquery.html#QUrlQuery-3

我的错。
