### PR TITLE
程序启动时输出用于构建当前程序的源代码的 Git 提交 SHA1

### DIFF
--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -91,6 +91,20 @@ RESOURCES += \
     resource.qrc
 
 
+# Git commit SHA1.
+isEmpty(GIT_COMMIT_SHA1) {
+    GIT_COMMIT_SHA1 = $$getenv(GIT_COMMIT_SHA1)
+}
+isEmpty(GIT_COMMIT_SHA1) {
+    error("\"GIT_COMMIT_SHA1\" is NOT set.")
+}
+!contains(GIT_COMMIT_SHA1, "^[0-9a-f]{40}$") {
+    error("\"GIT_COMMIT_SHA1\" is NOT a valid SHA1.")
+}
+message("GIT_COMMIT_SHA1 = $${GIT_COMMIT_SHA1}")
+DEFINES *= "GIT_COMMIT_SHA1=\\\"$${GIT_COMMIT_SHA1}\\\""
+
+
 # windows icon and exe file infomation
 win32{
 RC_FILE = Beslyric.rc

--- a/MiddleWidgets/SettingWidget/SuUpgrade.cpp
+++ b/MiddleWidgets/SettingWidget/SuUpgrade.cpp
@@ -61,6 +61,11 @@ QWidget *SuUpgrade::getUnitWidget(QWidget *parent)
     hLayout2->addWidget(btnCheckUpgrade);
     hLayout2->addSpacerItem(new QSpacerItem(20* BesScaleUtil::mscale(),20,QSizePolicy::MinimumExpanding, QSizePolicy::Fixed));
 
+    labelCurrentGitCommitSHA1 = new QLabel(SettingUnitContainer);
+    labelCurrentGitCommitSHA1->setTextInteractionFlags(Qt::TextInteractionFlag::TextSelectableByMouse);
+    labelCurrentGitCommitSHA1->setCursor(Qt::IBeamCursor);
+    labelCurrentGitCommitSHA1->setText(GIT_COMMIT_SHA1);
+
     labelNcmBeslyricAccount= new QLabel(SettingUnitContainer);
     labelNcmBeslyricAccount->setObjectName("labelSettingHighColor");
     labelNcmBeslyricAccount->setText(tr("<p style='line-height:130%'>更新检测可能由于数据存储迁移而失效，了解最新动态可关注： <a style='color:#666666;' href='https://music.163.com/#/user/home?id=349301179'>BesLyric 网易云音乐官方账号</a></p>"));
@@ -71,6 +76,7 @@ QWidget *SuUpgrade::getUnitWidget(QWidget *parent)
     vLayout->setSpacing(15* BesScaleUtil::mscale());
     vLayout->addLayout(hLayout1);
     vLayout->addLayout(hLayout2);
+    vLayout->addWidget(labelCurrentGitCommitSHA1);
     vLayout->addSpacerItem(new QSpacerItem(5,5* BesScaleUtil::mscale(), QSizePolicy::Fixed ,QSizePolicy::MinimumExpanding));
     vLayout->addWidget(labelNcmBeslyricAccount);
     vLayout->addSpacerItem(new QSpacerItem(5,5* BesScaleUtil::mscale(), QSizePolicy::Fixed ,QSizePolicy::MinimumExpanding));

--- a/MiddleWidgets/SettingWidget/SuUpgrade.h
+++ b/MiddleWidgets/SettingWidget/SuUpgrade.h
@@ -35,6 +35,7 @@ public:
 
 private:
     ThreadCheckUpdate threadCheck;
+    QLabel* labelCurrentGitCommitSHA1;
 };
 
 #endif // SuUpgrade_H

--- a/StackFrame.cpp
+++ b/StackFrame.cpp
@@ -341,5 +341,10 @@ void StackFrame::onUpdateResultFound(CheckUpgradeResult result)
 
 void StackFrame::showVersionInfo(){
     qDebug() << "VERSION: " << VERSION_NUMBER << ", COMMIT: " << GIT_COMMIT_SHA1;
+#if !defined(RELEASE_VERSION)
+    BesMessageBox::information(
+        tr("这是测试版"),
+        tr("版本： %1\n提交： %2").arg(VERSION_NUMBER).arg(GIT_COMMIT_SHA1));
+#endif
 }
 

--- a/StackFrame.cpp
+++ b/StackFrame.cpp
@@ -14,6 +14,7 @@ StackFrame::StackFrame(QApplication *pApplication,QWidget *parent)
 
     //先初始化设置（由于没有读取皮肤设置，先设置一个默认的皮肤，好在出错弹框时有一个默认皮肤）【第1次设置】
     SetSkin("black");
+    showVersionInfo();
     initSetting();
 
     QString skinName = SettingManager::GetInstance().data().skinName;
@@ -336,5 +337,9 @@ void StackFrame::onUpdateResultFound(CheckUpgradeResult result)
 
     BesMessageBox::information(tr("有新版本  ") + result.versionNum, strUpdate);
 
+}
+
+void StackFrame::showVersionInfo(){
+    qDebug() << "VERSION: " << VERSION_NUMBER << ", COMMIT: " << GIT_COMMIT_SHA1;
 }
 

--- a/StackFrame.h
+++ b/StackFrame.h
@@ -73,6 +73,7 @@ private:
     //登录记录
     ThreadLogin login;
     ThreadCheckUpdate checkUpdate;
+    void showVersionInfo();
 };
 
 #endif // STACKFRAME_H


### PR DESCRIPTION
用于 CI 。

<br>

将通过两种方式输出该 SHA1 ：

- qDebug()
- BesMessageBox::information()

<br>

需要在环境中设置或向 qmake 传入 `GIT_COMMIT_SHA1=...` 才能进行构建；可以使用 `git rev-parse HEAD` 以获取该 SHA1 。

Shell or PowerShell:

```console
> qmake -before "GIT_COMMIT_SHA1=$(git rev-parse HEAD)"
```
