### PR TITLE
在定义了 RELEASE_VERSION 时，定义 QT_NO_DEBUG_OUTPUT 以禁用 qDebug 

### DIFF
--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -44,9 +44,10 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-# To enable qDebug() under "release", disable QT_NO_DEBUG_OUTPUT bellow
-CONFIG (release, debug|release) {
-DEFINES *= QT_NO_DEBUG_OUTPUT
+# To disable qDebug(), pass "-before DEFINES*=RELEASE_VERSION" to qmake
+contains(DEFINES, "RELEASE_VERSION") {
+    message("DEFINES \"RELEASE_VERSION\" detected.")
+    DEFINES *= QT_NO_DEBUG_OUTPUT
 }
 
 INCLUDEPATH +=$$PWD BesWidgets


### PR DESCRIPTION
与 #77 、 #82 中的 3cae066a7613e3aca4eff8aed0cc299b7fa25347 有关。

在 CI 上，我们仅进行 release 配置的构建，同时也需要 `qDebug()` 的输出以进行测试，所以原来的办法，即通过 `CONFIG` 判断当前是否为 release 配置来决定是否禁用 `qDebug()` ，就变得不适用。

如果不进行任何配置， `qDebug()` 是启用的；当我们需要禁用 `qDebug()` ，例如制作分发给用户的发行版时，就要通过 `qmake '-before' 'DEFINES*=RELEASE_VERSION'` 传入宏 `RELEASE_VERSION` 以禁用 `qDebug()` 。

注意，宏 `RELEASE_VERSION` 还被用于 #127 中的 1bb29f4a0895f61be4e1e33c3562d5cd766380ef 。
