### PR TITLE
在 Windows 平台 将 lib 与 dll 文件放在同一个文件夹 以便在 Qt Creator 中调试

### DIFF
--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -201,12 +201,6 @@ win32 {
     }
     message("dep_lib_path = $${dep_lib_path}")
 
-    dep_bin_path = $$system_path($${dep_base_path}/bin)
-    !exists($${dep_bin_path}) {
-        error("\"$${dep_bin_path}\" does NOT exist.")
-    }
-    message("dep_bin_path = $${dep_bin_path}")
-
     INCLUDEPATH *= \
         $${dep_include_path} \
         $$system_path($${dep_include_path}/SDL2)
@@ -222,7 +216,6 @@ win32 {
         -lswscale \
         -lSDL2
 
-    unset(dep_bin_path)
     unset(dep_lib_path)
     unset(dep_include_path)
     unset(dep_base_path)


### PR DESCRIPTION
与 #123 的 f1c6b07332c8430da2dd1ab86e3cac8d4f122b99 有关。

将所有的 dll 和 lib 文件存储到文件夹 `%B4X_DEP_PATH%\lib\` 。

由于 `LIBS` 中的文件夹的路径会被添加到 Qt Creator 的“ Run Environment ”的 `PATH` 中，用户就可以直接在 Qt Creator 中运行 BesLyric-for-X 而不需要手动复制 dll 文件。

文档也更新了：
- Windows: https://github.com/BesLyric-for-X/BesLyric-for-X_Conf/tree/windows_x64_3.1.3_1
