### PR TITLE
添加 VS Code 的 .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,14 @@ target_wrapper.*
 
 # QtCreator CMake
 CMakeLists.txt.user*
+
+# VisualStudioCode.gitignore
+# from: https://github.com/github/gitignore/blob/218a941be92679ce67d0484547e3e142b2f5f6f0/Global/VisualStudioCode.gitignore
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+# Local History for Visual Studio Code
+.history/


### PR DESCRIPTION
来自 https://github.com/github/gitignore/blob/218a941be92679ce67d0484547e3e142b2f5f6f0/Global/VisualStudioCode.gitignore 。
