### PR TITLE
在 Windows 平台 使 Inno Setup 能够检查 本程序是否正在运行

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -9,6 +9,9 @@
 #include <QDebug>
 
 #include <LyricListManager.h>
+#ifdef Q_OS_WIN
+#include <synchapi.h>
+#endif
 
 
 void test()
@@ -21,6 +24,13 @@ void test()
 
 int main(int argc, char *argv[])
 {
+#ifdef Q_OS_WIN
+    // They are used to prevent the installer and the uninstaller of
+    //   Inno Setup from being executed while BesLyric-for-X is running.
+    CreateMutex(NULL, FALSE, TEXT("AppMutex_{7ACD3BB0-DE1F-416E-A8DC-5C6EE4AECB50}"));
+    CreateMutex(NULL, FALSE, TEXT("Global\\AppMutex_{7ACD3BB0-DE1F-416E-A8DC-5C6EE4AECB50}"));
+#endif
+
     MyApplication app(argc, argv);
     app.setApplicationName("BesLyric-for-X");
 

--- a/main.cpp
+++ b/main.cpp
@@ -10,7 +10,8 @@
 
 #include <LyricListManager.h>
 #ifdef Q_OS_WIN
-#include <synchapi.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #endif
 
 


### PR DESCRIPTION
我们将在 Inno Setup 脚本中使用 [Setup] 的 AppMutex 属性，以避免 Inno Setup 在 B4X 正在运行时进行 B4X 的安装或卸载，导致旧文件无法被移除等问题。

---

找到了一个示例代码： [Using Named Objects - Win32 apps | Microsoft Docs](https://docs.microsoft.com/en-us/windows/win32/sync/using-named-objects)
