### PR TITLE
使用 file_copies 自动复制所需的文件

### DIFF
--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -237,3 +237,19 @@ unix {
 }
 
 #--------------------------------
+
+# Copy the files used for packaging.
+#   https://stackoverflow.com/questions/3984104/qmake-how-to-copy-a-file-to-the-output/54162789#54162789
+
+CONFIG *= file_copies
+
+macx:  the_icon.files = $${_PRO_FILE_PWD_}/BesLyric.icns
+win32: the_icon.files = $${_PRO_FILE_PWD_}/Beslyric.ico
+the_icon.path = $${OUT_PWD}
+
+win32: version_txt.files = $${_PRO_FILE_PWD_}/version.txt
+version_txt.path = $${OUT_PWD}
+
+COPIES *= the_icon version_txt
+
+#--------------------------------


### PR DESCRIPTION
这些文件将被自动复制到输出目录 `OUT_PWD` ，并在之后被打包脚本所使用：

- 图标（ macOS 和 Windows ）；
- 版本信息（仅 Windows ）。

<br>

实现：

- https://code.qt.io/cgit/qt/qtbase.git/tree/mkspecs/features/file_copies.prf?id=7227e54445021b8c2ce4f4ab638cc7d43e32a5a7
- https://github.com/qt/qtbase/blob/7227e54445021b8c2ce4f4ab638cc7d43e32a5a7/mkspecs/features/file_copies.prf

Code review ：

- https://codereview.qt-project.org/c/qt/qtbase/+/156784

我从这里找到它：

- https://stackoverflow.com/questions/3984104/qmake-how-to-copy-a-file-to-the-output/54162789#54162789

<br>

又一个 undocumented feature 。
