### PR TITLE
Revert "使用“ DESTDIR ”变量分离二进制文件"

### DIFF
--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -154,16 +154,6 @@ ICON = BesLyric.icns
 
 #--------------------------------
 
-# Separate the binary file.
-CONFIG(debug, debug|release){
-    DESTDIR = $${OUT_PWD}/debug_bin
-}
-CONFIG(release, debug|release){
-    DESTDIR = $${OUT_PWD}/release_bin
-}
-
-#--------------------------------
-
 #屏蔽 msvc 编译器对 rational.h 的 warning: C4819: 该文件包含不能在当前代码页(936)中表示的字符。请将该文件保存为 Unicode 格式以防止数据丢失
 win32-msvc*:QMAKE_CXXFLAGS += /wd"4819"
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,3 @@ IDE: [QT Creator 5.7.1](https://download.qt.io/archive/qt/5.7/5.7.1/)
 
 2、本项目使用跨平台开源库 ffmpeg 解析播放音频文件，考虑到更新ffmpeg的灵活性 以及 跨平台要求的特性，Beslyric-for-X 中在使用 ffmpeg 时，不直接将其置于项目下，而是开发者在对应的平台上各自独立单独安装。具体开发说明置于 [beslyric-lib](https://github.com/BensonLaur/beslyric-lib) 项目中。
 
-#### 输出
-
-1. 生成的二进制文件在输出目录的`[ debug | release ]_bin`文件夹下。
-


### PR DESCRIPTION
Reverts ce907f965398447ae35e1bf5dde0a2f14161e3fd in #57 .

现在，我对于 qmake 的理解，相比于 #35 那时已经进步许多了，有更好的方式控制 qmake 的行为，所以也就不再需要硬编码目标的输出路径了。
