### PR TITLE
硬编码默认的版本号

### DIFF
--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -121,7 +121,7 @@ isEmpty(APP_VERSION) {
 }
 !contains(APP_VERSION, "^\d+\.\d+\.\d+$") {
     warning("\"$${APP_VERSION}\" is NOT a valid APP_VERSION. Use the default one.")
-    APP_VERSION = "0.0.0"
+    APP_VERSION = "3.1.2"
 }
 message("APP_VERSION = $${APP_VERSION}")
 


### PR DESCRIPTION
相关提交：

- #128 的 ea5340998c50021661165b75c54ae551d9a6326e ；
- #132 的 c8a93325a83256321d17e8eb4ed2d077b581c06e 。

版本控制系统并不总是可用的，因此不应该使用全零的默认版本号。
