### PR TITLE
Revert "使用 file_copies 自动复制所需的文件"

### DIFF
--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -227,19 +227,3 @@ unix {
 }
 
 #--------------------------------
-
-# Copy the files used for packaging.
-#   https://stackoverflow.com/questions/3984104/qmake-how-to-copy-a-file-to-the-output/54162789#54162789
-
-CONFIG *= file_copies
-
-macx:  the_icon.files = $${_PRO_FILE_PWD_}/BesLyric.icns
-win32: the_icon.files = $${_PRO_FILE_PWD_}/Beslyric.ico
-the_icon.path = $${OUT_PWD}
-
-win32: version_txt.files = $${_PRO_FILE_PWD_}/version.txt
-version_txt.path = $${OUT_PWD}
-
-COPIES *= the_icon version_txt
-
-#--------------------------------


### PR DESCRIPTION
Reverts BesLyric-for-X/BesLyric-for-X#136

由于 [INSTALLS](https://doc.qt.io/qt-5/qmake-variable-reference.html#installs) 的文件的安装位置可由参数 `INSTALL_ROOT` 控制，比 file_copies 更灵活，所以将其撤回，再在之后切换到 INSTALLS 。

同时，这也是为迁移到 CMake 铺路。
