### PR TITLE
使用 OTHER_FILES 替换 DISTFILES

### DIFF
--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -85,6 +85,8 @@ HEADERS  += \
     MyApplication.h
 
 OTHER_FILES += \
+    LICENSE \
+    README.md \
     version.txt
 
 RESOURCES += \

--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -84,7 +84,7 @@ HEADERS  += \
     StackFrame.h \
     MyApplication.h
 
-DISTFILES += \
+OTHER_FILES += \
     version.txt
 
 RESOURCES += \


### PR DESCRIPTION
这两个列表中的文件都会被显示在 Qt Creator 中，但是 `DISTFILES` 中的文件将被用于 `make dist` ， `OTHER_FILES` 则完全不影响 Makefile 。
