### PR TITLE
Get channel layout and sampling rate of the input audio from AVCodecContext

### DIFF
--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -451,7 +451,7 @@ bool PlayThread::initDeviceAndFfmpegContext()
     }
 
     //Out Audio Param
-    out_channel_layout=AV_CH_LAYOUT_STEREO;
+    out_channel_layout=pCodecCtx->channel_layout;
     //nb_samples: AAC-1024 MP3-1152
     out_nb_samples=pCodecCtx->frame_size;
     out_sample_fmt=AV_SAMPLE_FMT_S16;

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -455,7 +455,7 @@ bool PlayThread::initDeviceAndFfmpegContext()
     //nb_samples: AAC-1024 MP3-1152
     out_nb_samples=pCodecCtx->frame_size;
     out_sample_fmt=AV_SAMPLE_FMT_S16;
-    out_sample_rate=44100;
+    out_sample_rate=pCodecCtx->sample_rate;
     out_channels=av_get_channel_layout_nb_channels(out_channel_layout);
     //Out Buffer Size
     out_buffer_size=av_samples_get_buffer_size(NULL,out_channels ,out_nb_samples,out_sample_fmt, 1);


### PR DESCRIPTION
The symptoms of noise during playback and abnormal high-speed playback will be fixed by 46c78a09f5a4cce6b381ed2e590a921c4d43b49f !

AVCodecContext provides everything we need, but was ignored by us.

See commit message for details.
