### PR TITLE
fix: Hide the `verticalHeader` of all `QTableView`

### DIFF
--- a/BesWidgets/table/BesLListTableView.cpp
+++ b/BesWidgets/table/BesLListTableView.cpp
@@ -89,7 +89,7 @@ void BesLListTableView::BaseInit()
     this->setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);
     this->setColumnWidth(0,50);
     this->setColumnWidth(1,100);
-    this->verticalHeader()->setVisible(true);
+    this->verticalHeader()->setVisible(false);
     this->horizontalHeader()->setSectionResizeMode(0,QHeaderView::ResizeMode::Fixed);
     this->horizontalHeader()->setSectionResizeMode(1,QHeaderView::ResizeMode::Fixed);
     this->horizontalHeader()->setMinimumSectionSize(50);

--- a/BesWidgets/table/BesLrcTableView.cpp
+++ b/BesWidgets/table/BesLrcTableView.cpp
@@ -57,7 +57,7 @@ void BesLrcTableView::BaseInit()
     this->setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);
     this->setColumnWidth(0,50);
     this->setColumnWidth(4,240);
-    this->verticalHeader()->setVisible(true);
+    this->verticalHeader()->setVisible(false);
     this->horizontalHeader()->setSectionResizeMode(0,QHeaderView::ResizeMode::Fixed);
     this->horizontalHeader()->setSectionResizeMode(4,QHeaderView::ResizeMode::Fixed);
     this->horizontalHeader()->setMinimumSectionSize(50);

--- a/BesWidgets/table/BesNcmSongTableView.cpp
+++ b/BesWidgets/table/BesNcmSongTableView.cpp
@@ -233,7 +233,7 @@ void BesNcmSongTableView::BaseInit()
     this->setColumnWidth(0,50);
     this->setColumnWidth(1,100);
     this->setColumnWidth(5,120);
-    this->verticalHeader()->setVisible(true);
+    this->verticalHeader()->setVisible(false);
     this->horizontalHeader()->setSectionResizeMode(0,QHeaderView::ResizeMode::Fixed);
     this->horizontalHeader()->setSectionResizeMode(1,QHeaderView::ResizeMode::Fixed);
     this->horizontalHeader()->setSectionResizeMode(5,QHeaderView::ResizeMode::Fixed);

--- a/BesWidgets/table/FinishLrcTableView.cpp
+++ b/BesWidgets/table/FinishLrcTableView.cpp
@@ -100,7 +100,7 @@ void FinishLrcTableView::BaseInit()
     this->setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);
     this->setColumnWidth(0,120);
     this->setColumnWidth(2,120);
-    this->verticalHeader()->setVisible(true);
+    this->verticalHeader()->setVisible(false);
     this->horizontalHeader()->setSectionResizeMode(0,QHeaderView::ResizeMode::Fixed);
     this->horizontalHeader()->setSectionResizeMode(2,QHeaderView::ResizeMode::Fixed);
     this->horizontalHeader()->setMinimumSectionSize(50);


### PR DESCRIPTION
fixes #157