### PR TITLE
fix: 在删除歌词单列表单项时，恰当地更新其布局

### DIFF
--- a/BesWidgets/table/BesLListTableView.cpp
+++ b/BesWidgets/table/BesLListTableView.cpp
@@ -49,7 +49,7 @@ void BesLListTableView::setDataSource(LyricList *pData)
 
 void BesLListTableView::reloadTableFromData()
 {
-    this->update();
+    emit m_model->layoutChanged();
 }
 
 void BesLListTableView::initEntity()


### PR DESCRIPTION
BesLListTableView 的 update 只会刷新除了表头外的部分，而直接发送其`Model` 的 `layoutChanged()` 信号则可以刷新包括表头部分的显示

Resolves #159