### PR TITLE
fix: 拖动左侧歌词单列表之后，发送`currentRowChanged`消息更新右侧歌词单表项

### DIFF
--- a/BesWidgets/list/BesList.cpp
+++ b/BesWidgets/list/BesList.cpp
@@ -156,6 +156,9 @@ void BesList::rowsMoved(const QModelIndex &parent, int start, int end, const QMo
     pLyricLists->insert(to,item);
 
     emit sig_saveLyriclistData();
+
+    //拖动变换顺序之后，通知当前选择行发生改变，以使得外部可以重新加载
+    emit currentRowChanged(to);
 }
 
 void BesList::enterEvent(QEvent *event)


### PR DESCRIPTION
fixes #175