### PR TITLE
feat: 在歌词单内容发生改变时，获取并更新歌词单封面

### DIFF
--- a/BesWidgets/list/BesList.cpp
+++ b/BesWidgets/list/BesList.cpp
@@ -29,33 +29,35 @@ void BesList::setLyricLists(QVector<LyricList> &lyricLists)
     //创建歌词单项
     for(auto& list:*pLyricLists)
     {
-        addItem(list.name, false);
+        QString imageName = getImageNameByTitleAndSkinName(list.name, currentSkinName);
+
+        QListWidgetItem *pItem = new QListWidgetItem(this);
+        pItem->setIcon(QIcon(imageName));
+        pItem->setText(list.name);
     }
 }
 
-
-void BesList::addItem(QString item, bool bConstructNewData)
+void BesList::addItem(QString item, int newId)
 {
     if(pLyricLists==nullptr)
         return;
 
-    LyricList lyricList;
-    lyricList.name = item;
-
+    //构建列表项
     QString imageName = getImageNameByTitleAndSkinName(item, currentSkinName);
 
     QListWidgetItem *pItem = new QListWidgetItem(this);
     pItem->setIcon(QIcon(imageName));
-    pItem->setText(lyricList.name);
+    pItem->setText(item);
 
-    if (bConstructNewData)
-    {
-        pLyricLists->push_back(lyricList);
-        emit sig_saveLyriclistData();
+    this->setMaximumHeight(35 * pLyricLists->size());
+    this->setMinimumHeight(35 * pLyricLists->size());
 
-        this->setMaximumHeight(35 * pLyricLists->size());
-        this->setMinimumHeight(35 * pLyricLists->size());
-    }
+    //构建实际的数据
+    LyricList lyricList;
+    lyricList.name = item;
+    lyricList.id = newId;
+    pLyricLists->push_back(lyricList);
+    emit sig_saveLyriclistData();
 }
 
 void BesList::deleteCurrentItem()

--- a/BesWidgets/list/BesList.h
+++ b/BesWidgets/list/BesList.h
@@ -16,7 +16,7 @@ public:
 
     void setLyricLists(QVector<LyricList>& lyricLists);
 
-    void addItem(QString item, bool bConstructNewData = true);
+    void addItem(QString item, int newId);
     void deleteCurrentItem();
     void removeAll();
 

--- a/Entities/LyricListManager.cpp
+++ b/Entities/LyricListManager.cpp
@@ -49,6 +49,7 @@ bool LyricListManager::saveLyricListData(LyricListData data)
             writer.writeStartElement("list"); // 开始元素<list>
 
             writer.writeAttribute("name", data.listsHistory[j].name);
+            writer.writeAttribute("albumCoverPath", data.listsHistory[j].albumCoverPath);
 
             for(int i = 0; i<data.listsHistory[j].items.size(); i++)
             {
@@ -71,6 +72,7 @@ bool LyricListManager::saveLyricListData(LyricListData data)
             writer.writeStartElement("list"); // 开始元素<list>
 
             writer.writeAttribute("name", data.listsCreated[j].name);
+            writer.writeAttribute("albumCoverPath", data.listsCreated[j].albumCoverPath);
 
             for(int i = 0; i<data.listsCreated[j].items.size(); i++)
             {
@@ -243,6 +245,13 @@ bool LyricListManager::parseLyricList(QXmlStreamReader &reader, QVector<LyricLis
                 }
                 else
                     return false;
+
+                //获取封面路径
+                if (attributes.hasAttribute("albumCoverPath")) {
+                    QString albumCoverPath = attributes.value("albumCoverPath").toString();
+                    lyricList.albumCoverPath = albumCoverPath;
+                    qDebug() << QString::fromLocal8Bit("attribute: albumCoverPath(%1)").arg(albumCoverPath);
+                }
 
                 //获取具体项
                 while (!reader.atEnd()) {

--- a/Entities/LyricListManager.h
+++ b/Entities/LyricListManager.h
@@ -28,7 +28,11 @@ class LyricList
 {
 public:
     QString name;
+    QString albumCoverPath;
     QVector<LyricListItem> items;
+
+    //辅助变量，用于异步获取专辑图片后，将图片匹配赋值到歌词单
+    int id = 0;
 };
 
 class LyricListData

--- a/Entities/MP3Editor/AlbumImageHelper.hpp
+++ b/Entities/MP3Editor/AlbumImageHelper.hpp
@@ -1,0 +1,94 @@
+﻿#ifndef H_AlbumImageHelper_hpp
+#define H_AlbumImageHelper_hpp
+
+#include "LyricListManager.h"
+#include <QRunnable>
+#include <QDebug>
+
+extern "C" {
+    #include "ffmpegDefine.h"
+}
+
+class AlbumImageHelper :public QObject, public QRunnable
+{
+    Q_OBJECT
+public:
+    AlbumImageHelper* SetDataAndGetPointer(const LyricList& list)
+    {
+        lyricList = list;
+        return this;
+    }
+
+    virtual void run()
+    {
+        qDebug()<<"start running AlbumImageHelper";
+        QPixmap pixmap;
+        if(GetFirstAvailableAlbumImage(lyricList, pixmap))
+        {
+            qDebug()<<"emit sig_lyricListAblumFound [lyricList.id]:" << lyricList.id;
+            emit sig_lyricListAblumFound(lyricList.id, pixmap);
+        }
+    }
+
+signals:
+    void sig_lyricListAblumFound(int listId, QPixmap pixmap);
+
+private:
+    bool GetFirstAvailableAlbumImage(const LyricList& list, QPixmap& pixmap)
+    {
+        for(auto& item:list.items)
+        {
+            if(GetSongAlbum(item.song, pixmap))
+                return true;
+        }
+
+        return false;
+    }
+
+    bool GetSongAlbum(const QString& song, QPixmap& pixmap)
+    {
+        //获得文件路径
+        char url[1024];
+        strcpy_s(url, song.toUtf8());
+
+        AVFormatContext	*pFormatCtx = avformat_alloc_context();
+
+        //打开输入流
+        if(avformat_open_input(&pFormatCtx,url,NULL,NULL)!=0){
+            qDebug()<<"Couldn't open input stream.";
+            return false;
+        }
+
+        // 获取流信息
+        if(avformat_find_stream_info(pFormatCtx,NULL)<0){
+            qDebug()<<"Couldn't find stream information.";
+            return false;
+        }
+
+        //这里仅仅读取 wav 或 mp3 格式的文件的图片信息
+        bool bFound = false;
+        if (strcmp(pFormatCtx->iformat->name, "wav") == 0 || strcmp(pFormatCtx->iformat->name, "mp3") == 0)
+        {
+            //读取专辑图片
+            for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
+                if (pFormatCtx->streams[i]->disposition & AV_DISPOSITION_ATTACHED_PIC) {
+                    AVPacket pkt = pFormatCtx->streams[i]->attached_pic;
+                    //使用QImage读取完整图片数据（注意，图片数据是为解析的文件数据，需要用QImage::fromdata来解析读取）
+                    QImage img = QImage::fromData((uchar*)pkt.data, pkt.size);
+                    pixmap = QPixmap::fromImage(img);
+
+                    bFound = true;
+                    break;
+                }
+            }
+        }
+
+        avformat_close_input(&pFormatCtx);
+
+        return bFound;
+    }
+
+    LyricList lyricList;
+};
+
+#endif //!H_AlbumImageHelper_hpp

--- a/Entities/MP3Editor/mp3Editor.pri
+++ b/Entities/MP3Editor/mp3Editor.pri
@@ -1,7 +1,8 @@
 
 HEADERS+=\
     $$PWD/mp3Editor.h\
-    $$PWD/ffmpegDefine.h
+    $$PWD/ffmpegDefine.h\
+    $$PWD/AlbumImageHelper.hpp
 
 SOURCES+=\
     $$PWD/mp3Editor.cpp

--- a/MiddleWidgets/PageLyricList.h
+++ b/MiddleWidgets/PageLyricList.h
@@ -13,6 +13,7 @@
 #include "BesFileLineEdit.h"
 #include "BoxPagePreviewLyric.h"
 #include <table/BesLListViewStyle.hpp>
+#include <Entities/MP3Editor/AlbumImageHelper.hpp>
 
 class PageLyricList : public QWidget
 {
@@ -52,11 +53,17 @@ public slots:
 
     //基础颜色发生改变
     void baseColorChanged(QColor color);
+
+    //找到了专辑图片
+    void OnLyricListAblumFound(int listId, QPixmap pixmap);
 private:
     void reloadLyricListData(LyricList* pLyricListData, bool canEditAndDelete);
 
     //是否进入对 indexEdited 下标对应的项的编辑模式
     void enableEditMode(bool bEnable, int indexEdited = -1);
+
+    //更新当前列表的封面
+    void UpdateCurrentListCover();
 
 public:
     QWidget * pageLyricListContainer;
@@ -117,6 +124,9 @@ public:
 
     int currentEditIndex;               //当前正在编辑的项目的下标
     bool isShowingHistory;              //正在显示的是否是 “制作历史” 歌词单
+
+    AlbumImageHelper albumImageHelper;  //用于获取歌词单的封面
+    int globalListId = 0;               //用于为歌词单分配临时的唯一的id，方便异步获取图片后匹配到原来的歌词单
 };
 
 #endif // PAGELYRICLIST_H


### PR DESCRIPTION
1. 新建继承自 `QRunable` 的 `AlbumImageHelper` 类，用于获取歌词单的歌曲中的第一个有效专辑封面
2. 为每一个歌词单赋值一个全局id，方便异步获取图片后，匹配回对应的歌词单
3. 优化 `BesList` 新增新歌词单列表项的接口 `addItem`, 以支持在构建新项时，传入新的 `id`
4. 歌词单存储结构中，新增 `albumCoverPath` 存储专辑图片的路径
5. 在歌词单项增、删、改，以及拖动改变顺序时，启动线程获取列表从上到下第一个有效歌曲专辑封面
6. 获取新的歌词单封面后，保存数据，并刷新显示图片

+ Resolves #164