### PR TITLE
fix: 调大若干控件尺寸大小，解决部分显示不全问题

### DIFF
--- a/Entities/SkinFactory/ISkin.h
+++ b/Entities/SkinFactory/ISkin.h
@@ -1007,7 +1007,7 @@ private:
         "   border-bottom:"+scaleNum(5)+"px solid;"
         "   color:"+ DeepLabelColor+";"
         "   border-bottom-color: rgba(0, 0, 0, 0);"
-        "   min-width: "+scaleNum(96)+"px;"
+        "   min-width: "+scaleNum(150)+"px;"
         "}"
 
         "QTabBar:tab:selected {"

--- a/MiddleWidgets/SettingWidget/SuDonation.cpp
+++ b/MiddleWidgets/SettingWidget/SuDonation.cpp
@@ -45,8 +45,8 @@ QWidget *SuDonation::getUnitWidget(QWidget *parent)
     btnDownloadLinux->setObjectName("btnDownloadLinux");
     btnDownloadMac->setObjectName("btnDownloadMac");
 
-    btnDownloadWindow->setMinimumSize(100,30);
-    btnDownloadWindow->setMaximumSize(100,30);
+    btnDownloadWindow->setMinimumSize(120,30);
+    btnDownloadWindow->setMaximumSize(120,30);
     btnDownloadLinux->setMinimumSize(90,30);
     btnDownloadLinux->setMaximumSize(90,30);
     btnDownloadMac->setMinimumSize(80,30);

--- a/MiddleWidgets/SettingWidget/SuUpgrade.cpp
+++ b/MiddleWidgets/SettingWidget/SuUpgrade.cpp
@@ -42,8 +42,8 @@ QWidget *SuUpgrade::getUnitWidget(QWidget *parent)
     labelCurrentVersionTip = new QLabel(SettingUnitContainer);
     labelCurrentVersion    = new QLabel(SettingUnitContainer);
     labelCurrentVersionTip->setText("当前版本号：");
-    labelCurrentVersionTip->setMinimumSize(100* BesScaleUtil::scale(),30* BesScaleUtil::scale());
-    labelCurrentVersionTip->setMaximumSize(100* BesScaleUtil::scale(),30* BesScaleUtil::scale());
+    labelCurrentVersionTip->setMinimumSize(150* BesScaleUtil::scale(),30* BesScaleUtil::scale());
+    labelCurrentVersionTip->setMaximumSize(150* BesScaleUtil::scale(),30* BesScaleUtil::scale());
     labelCurrentVersionTip->setAlignment(Qt::AlignRight|Qt::AlignVCenter);
     labelCurrentVersion->setMinimumSize(50* BesScaleUtil::scale(),30* BesScaleUtil::scale());
     labelCurrentVersion->setMaximumSize(50* BesScaleUtil::scale(),30* BesScaleUtil::scale());
@@ -54,7 +54,7 @@ QWidget *SuUpgrade::getUnitWidget(QWidget *parent)
 
     QHBoxLayout* hLayout2 = new QHBoxLayout();
     hLayout2->addWidget(checkboxAutoUpgrade);
-    hLayout2->addSpacerItem(new QSpacerItem(120* BesScaleUtil::scale(),20,QSizePolicy::Fixed, QSizePolicy::Fixed));
+    hLayout2->addSpacerItem(new QSpacerItem(60* BesScaleUtil::scale(),20,QSizePolicy::Fixed, QSizePolicy::Fixed));
     hLayout2->addWidget(labelCurrentVersionTip);
     hLayout2->addWidget(labelCurrentVersion);
     hLayout2->addSpacerItem(new QSpacerItem(10* BesScaleUtil::scale(),40* BesScaleUtil::scale(),QSizePolicy::Fixed, QSizePolicy::Fixed));

--- a/MiddleWidgets/SubPageMaking.cpp
+++ b/MiddleWidgets/SubPageMaking.cpp
@@ -271,9 +271,9 @@ void SubPageMaking::initLayout()
     labelTimeTip->setText(tr("00:00.000"));
     labelCurrenLineTip->setText(tr("当前行："));
     labelNextLineTip->setText(tr("下一行："));
-    labelTimeTip->setMinimumSize(100,28* BesScaleUtil::scale());
-    labelCurrenLineTip->setMinimumSize(100,28* BesScaleUtil::scale());
-    labelNextLineTip->setMinimumSize(100,28* BesScaleUtil::scale());
+    labelTimeTip->setMinimumSize(110,28* BesScaleUtil::scale());
+    labelCurrenLineTip->setMinimumSize(110,28* BesScaleUtil::scale());
+    labelNextLineTip->setMinimumSize(110,28* BesScaleUtil::scale());
     labelTimeTip->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     labelCurrenLineTip->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     labelNextLineTip->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
@@ -361,8 +361,8 @@ void SubPageMaking::initLayout()
 
     btnEditLyricCurrent = new BesButton(widgetLine0);
     btnEditLyricCurrent->setText(tr("单行编辑"));
-    btnEditLyricCurrent->setMinimumSize(75,28* BesScaleUtil::scale());
-    btnEditLyricCurrent->setMaximumSize(75,28* BesScaleUtil::scale());
+    btnEditLyricCurrent->setMinimumSize(85,28* BesScaleUtil::scale());
+    btnEditLyricCurrent->setMaximumSize(85,28* BesScaleUtil::scale());
     btnEditLyricCurrent->setSizePolicy(QSizePolicy::Fixed,QSizePolicy::Fixed);
 
     QHBoxLayout* hLayoutLine0 = new QHBoxLayout();
@@ -376,8 +376,8 @@ void SubPageMaking::initLayout()
 
     btnEditBatchLyric = new BesButton(widgetLine4);
     btnEditBatchLyric->setText(tr("批量编辑"));
-    btnEditBatchLyric->setMinimumSize(75,28* BesScaleUtil::scale());
-    btnEditBatchLyric->setMaximumSize(75,28* BesScaleUtil::scale());
+    btnEditBatchLyric->setMinimumSize(85,28* BesScaleUtil::scale());
+    btnEditBatchLyric->setMaximumSize(85,28* BesScaleUtil::scale());
     btnEditBatchLyric->setSizePolicy(QSizePolicy::Fixed,QSizePolicy::Fixed);
 
     QHBoxLayout* hLayoutLine4 = new QHBoxLayout();


### PR DESCRIPTION
1. 调大所有的 QTabBar 的最小宽度: scaleNum(96) px ->scaleNum(150) px
2. 调大标签 "当前版本号：" 的宽度: 100->150
3. 调大制作歌词页面 "单行编辑" 和 “批量编辑” 标签大小: 75->85
4. 调大下载软件按钮: 100->120

相关 issue: #181