### PR TITLE
fix: 计算 BesMessageBox 宽度时，考虑多行文本以及富文本的情况

### DIFF
--- a/BesWidgets/BesMessageBox.cpp
+++ b/BesWidgets/BesMessageBox.cpp
@@ -1,6 +1,7 @@
 ﻿#include "global.h"
 #include "BesMessageBox.h"
 #include "BesScaleUtil.h"
+#include <QTextDocument>
 
 BesMessageBox* BesMessageBox::besMessageBox = nullptr;
 
@@ -184,9 +185,31 @@ void BesMessageBox::limitBoxWidth(BesMessageBox *besMessageBox, const QString &t
     //上面重置窗口的最小宽度的依据，是参考以上数据，取一个相对舒服的大概的宽度
     //—— 当 widthWidgetTotal > 800 时，widthWindow 设置为 1000
 
-    int widthText = besMessageBox->labelMessageContent->fontMetrics().boundingRect(text).width();
+    QString plainText;
+    if(text.contains('\n'))
+        plainText = text; //含有 \n 时，认为本身就是 plain text
+    else
+    {
+        //不含有 \n 时，认为本身可能是 HTML 富文本，尝试转为plain text
+        QTextDocument textDocument;
+        textDocument.setHtml(text);
+        plainText = textDocument.toPlainText();
+    }
+
+    //计算每行的宽度，得到最大宽度
+    int maxWidthText = 0;
+    QFontMetrics fm = besMessageBox->labelMessageContent->fontMetrics();
+    QStringList lines = plainText.split('\n');
+    for(auto line:lines)
+    {
+        int width = fm.boundingRect(line).width();
+        if(width > maxWidthText)
+            maxWidthText = width;
+    }
+
+    //估算整体宽度
     int widthIcon = (48+15*2)* BesScaleUtil::scale();
-    int widthWidgetTotal = widthIcon + widthText;
+    int widthWidgetTotal = widthIcon + maxWidthText;
     if(widthWidgetTotal > 800)
     {
         //不允许宽度太宽，超出一定宽度时，设置一个最小宽度，并且文字可换行


### PR DESCRIPTION
1. 先前测试的情况只考虑到单行提示的情况，计算宽度时没有测试包含换行符的情况
2. 现在计算宽度时，以 `\n` 为分割符得到多行，以宽度最大的行为文本整体宽度
3. 显示富文本的情况，比如版本更新信息，先转为 plain text，再按第 2 点计算

patch for d224c9f65c8a2308216296edc127f32cf529e31
Resolves #188