### PR TITLE
The lyricListCreated list cannot display the newly created LyricList correctly

### DIFF
--- a/BesWidgets/list/BesList.cpp
+++ b/BesWidgets/list/BesList.cpp
@@ -49,15 +49,15 @@ void BesList::addItem(QString item, int newId)
     pItem->setIcon(QIcon(imageName));
     pItem->setText(item);
 
-    this->setMaximumHeight(35 * pLyricLists->size());
-    this->setMinimumHeight(35 * pLyricLists->size());
-
     //构建实际的数据
     LyricList lyricList;
     lyricList.name = item;
     lyricList.id = newId;
     pLyricLists->push_back(lyricList);
     emit sig_saveLyriclistData();
+
+    this->setMaximumHeight(35 * pLyricLists->size());
+    this->setMinimumHeight(35 * pLyricLists->size());
 }
 
 void BesList::deleteCurrentItem()


### PR DESCRIPTION
Fix https://github.com/BesLyric-for-X/BesLyric-for-X/pull/179#pullrequestreview-730302318 .

## Details 

After applying 96949ac42f17352ce022b28f8b11df19f5bfa130 ( #179 ), in PageLyricList, I found a bug with lyricListCreated (the list of user created LyricLists).

When I create a new LyricList:

- If lyricListCreated is empty, it will not display the new LyricList immediately until another LyricList is created.
- If lyricListCreated is not empty, it will not increase its height to fit the number of LyricLists, but keep the previous size and display a vertical scrollbar, regardless of whether its maximum height is really too big to fit in its container (vListLayout). Adding more LyricLists will increase its height, but the total height will be always 1 less than the actual number of LyricLists. For instance, if there are two LyricLists in lyricListCreated (one is newer), it will be as high as one LyricList and display a scrollbar.
