### PR TITLE
Also consider the width of the available desktop space before scaling pixels

### DIFF
--- a/BesWidgets/BesScaleUtil.h
+++ b/BesWidgets/BesScaleUtil.h
@@ -12,14 +12,17 @@ public:
         //获取主屏幕可用大小
         QRect primaryScreenRect = getPrimaryScreenRect();
 
-        //分辨率高小于 800 时，按比例缩放
-        //分辨率高大于等于 800 时，不缩放
-        //使用例子：窗口的基础高度为 800px, 实际的设置高度为 800 * BesScaleUtil::scale()
+        //分辨率高小于 800 或宽小于 1224 时，按比例缩放
+        //分辨率高大于等于 800 且宽大于等于 1224 时，不缩放
+        //使用例子：窗口的基础高度与宽度分别为 800px 与 1224px , 实际设置的高度与宽度分别为 800 * BesScaleUtil::scale() 与 1224 * BesScaleUtil::scale()
 
-        if(primaryScreenRect.height() < 800)
-            return primaryScreenRect.height() / 800.0;
-        else
+        double heightScalingRatio = primaryScreenRect.height() / 800.0;
+        double widthScalingRatio = primaryScreenRect.width() / 1224.0;
+
+        if(heightScalingRatio >= 1.0 && widthScalingRatio >= 1.0)
             return 1.0;
+
+        return heightScalingRatio < widthScalingRatio ? heightScalingRatio : widthScalingRatio;
     }
 
     static QRect getPrimaryScreenRect()


### PR DESCRIPTION
# Summary

We don't like that our application (B4X) is too big to fit into the desktop. The size of the desktop varies, so we should think more about it. The height has already been considered, but the width has not. Thus, I made this PR.

# Credits

- [HTML Tables generator – TablesGenerator.com](https://www.tablesgenerator.com/html_tables)

# Test result

All tests are performed on VMware® Workstation 16 Pro 16.1.2 build-17966106 (unlocked).

Like the previous PR, on Windows, I followed [Increasing virtual machine display resolution to a custom resolution beyond the maximum resolution listed in Microsoft Windows (2058577)](https://kb.vmware.com/s/article/2058577) to adjust the resolution. On macOS, I used [MarLoe/VMware.PreferencePane](https://github.com/MarLoe/VMware.PreferencePane) to make resolution adjustment easier. On Ubuntu, I had to call `gtf` and `xrandr` in X11 environment like [Getting 1920x1080 resolution or 16:9 aspect ratio on Ubuntu or Linux Mint - Super User](https://superuser.com/questions/758463/getting-1920x1080-resolution-or-169-aspect-ratio-on-ubuntu-or-linux-mint).

## macOS Big Sur 11.1 (20C69)

Basic information:

<table>
<tbody>
  <tr>
    <td rowspan="3">QSysInfo</td>
    <td>kernelType()</td>
    <td>darwin</td>
  </tr>
  <tr>
    <td>kernelVersion()</td>
    <td>20.2.0</td>
  </tr>
  <tr>
    <td>prettyProductName()</td>
    <td>macOS 10.16</td>
  </tr>
  <tr>
    <td rowspan="2">QApplication::font()</td>
    <td>pointSize()</td>
    <td>13</td>
  </tr>
  <tr>
    <td>family()</td>
    <td>.AppleSystemUIFont</td>
  </tr>
</tbody>
</table>

### 1024x768@1x (XGA, landscape)

Screenshot:

| original | 96e77158e123963f730435238bb7ed26235962a4
| - | -
| ![20210828-210331-macOS-11 1-1024x768-original](https://user-images.githubusercontent.com/29089388/131221650-5a2973d4-77d4-4de2-8355-73dcc4580fff.jpg) | ![20210828-210350-macOS-11 1-1024x768-height_and_width](https://user-images.githubusercontent.com/29089388/131221657-22a4623e-9bcc-4781-be2b-3eda100db1c1.jpg)

### 1080x1920@1x (FHD, portrait)

Screenshot:

| original | 96e77158e123963f730435238bb7ed26235962a4
| - | -
| ![20210828-210440-macOS-11 1-1080x1920-original](https://user-images.githubusercontent.com/29089388/131221660-79364de4-756c-4097-a159-758ce1f19e24.jpg) | ![20210828-210500-macOS-11 1-1080x1920-height_and_width](https://user-images.githubusercontent.com/29089388/131221666-cf31b445-84a4-4b4d-9329-113718320d3b.jpg)

## Ubuntu 20.04.2.0 LTS (Focal Fossa)

Basic information:

<table>
<tbody>
  <tr>
    <td rowspan="3">QSysInfo</td>
    <td>kernelType()</td>
    <td>linux</td>
  </tr>
  <tr>
    <td>kernelVersion()</td>
    <td>5.8.0-43-generic</td>
  </tr>
  <tr>
    <td>prettyProductName()</td>
    <td>Ubuntu 20.04.2 LTS</td>
  </tr>
  <tr>
    <td rowspan="2">QApplication::font()</td>
    <td>pointSize()</td>
    <td>9</td>
  </tr>
  <tr>
    <td>family()</td>
    <td>Sans Serif</td>
  </tr>
</tbody>
</table>

### 1024x768 (XGA, landscape) Scale 100

Screenshot:

| original | 96e77158e123963f730435238bb7ed26235962a4
| - | -
| ![20210828-172829-ubuntu-20 04 2 0-1024x768-original](https://user-images.githubusercontent.com/29089388/131221624-7637e556-1415-4796-bc93-177d5a85d48a.jpg) | ![20210828-172858-ubuntu-20 04 2 0-1024x768-height_and_width](https://user-images.githubusercontent.com/29089388/131221626-d684b3e4-45a0-4267-b985-ebfcd96e4a7f.jpg)

### 1080x1920 (FHD, portrait) Scale 100

Screenshot:

| original | 96e77158e123963f730435238bb7ed26235962a4
| - | -
| ![20210828-173524-ubuntu-20 04 2 0-1080x1920-original](https://user-images.githubusercontent.com/29089388/131221629-4b63f094-6932-49a2-b0f1-bfdfe1188aa7.jpg) | ![20210828-173548-ubuntu-20 04 2 0-1080x1920-height_and_width](https://user-images.githubusercontent.com/29089388/131221631-f3b866d8-189d-4128-be75-163fe81da052.jpg)

## Windows 10 Pro N 21H1 10.0.19043.1110

Basic information:

<table>
<tbody>
  <tr>
    <td rowspan="3">QSysInfo</td>
    <td>kernelType()</td>
    <td>winnt</td>
  </tr>
  <tr>
    <td>kernelVersion()</td>
    <td>10.0.19043</td>
  </tr>
  <tr>
    <td>prettyProductName()</td>
    <td>Windows 10 Version 2009</td>
  </tr>
  <tr>
    <td rowspan="2">QApplication::font()</td>
    <td>pointSize()</td>
    <td>8</td>
  </tr>
  <tr>
    <td>family()</td>
    <td>MS Shell Dlg 2</td>
  </tr>
</tbody>
</table>

### 1024x768 (XGA, landscape) Scale 100

Screenshot:

| original | 96e77158e123963f730435238bb7ed26235962a4
| - | -
| ![20210828-192707-win10-21h1-jul_2021-1024x768-original](https://user-images.githubusercontent.com/29089388/131221633-0d876c08-ec82-46e3-b071-16be6da9f6f1.jpg) | ![20210828-192733-win10-21h1-jul_2021-1024x768-height_and_width](https://user-images.githubusercontent.com/29089388/131221636-68f2d91b-d206-4968-8c6d-fe457b8e4207.jpg)

### 1080x1920 (FHD, portrait) Scale 100

Screenshot:

| original | 96e77158e123963f730435238bb7ed26235962a4
| - | -
| ![20210828-193041-win10-21h1-jul_2021-1080x1920-original](https://user-images.githubusercontent.com/29089388/131221638-264f50f1-d31d-42bb-b17a-975c05e2e1d9.jpg) | ![20210828-193106-win10-21h1-jul_2021-1080x1920-height_and_width](https://user-images.githubusercontent.com/29089388/131221642-a55c5f2b-d153-4fb8-982a-7e11ed32ee27.jpg)
