### PR TITLE
refactor: 将网易云专属请求头从 SyncDownloadStringPost 移至调用方

### DIFF
--- a/Entities/LyricSearcherFactory/SearcherNetEaseCloud.cpp
+++ b/Entities/LyricSearcherFactory/SearcherNetEaseCloud.cpp
@@ -62,7 +62,11 @@ bool SearcherNetEaseCloud::GetSongListWithNameAndArtist(QString strSong, QString
     queryData.append("csrf_token=&s="+encodedArtist+"+"+ encodedSong +"&type=1&offset=0&total=True&limit=20");
 
     QString strRes;
-    if(!NetworkAccess::SyncDownloadStringPost( "https://music.163.com/api/v1/search/get",strRes,queryData))
+    QMap<QByteArray, QByteArray> headers = {
+        {"User-Agent", "NeteaseMusic/9.0.90 (iPhone; iOS 17.0; Scale/3.00)"},
+        {"Referer", "https://music.163.com"}
+    };
+    if(!NetworkAccess::SyncDownloadStringPost( "https://music.163.com/api/v1/search/get",strRes,queryData,headers))
     {
         strLastResult = tr("网络连接失败，无法获取索引数据");
         return false;

--- a/Entities/Thread/ThreadConvertMp3.cpp
+++ b/Entities/Thread/ThreadConvertMp3.cpp
@@ -98,7 +98,11 @@ bool ThreadConvertMp3::downloadNcmInfo(int ncmId, NcmDetailInfo& info, QString& 
     QByteArray queryData;
     queryData.append("id="+strNcmId+"&ids=%5B" + strNcmId+"%5D");
     QString strRes;
-    if(!NetworkAccess::SyncDownloadStringPost( "https://music.163.com/api/song/detail/",strRes,queryData))
+    QMap<QByteArray, QByteArray> headers = {
+        {"User-Agent", "NeteaseMusic/9.0.90 (iPhone; iOS 17.0; Scale/3.00)"},
+        {"Referer", "https://music.163.com"}
+    };
+    if(!NetworkAccess::SyncDownloadStringPost( "https://music.163.com/api/song/detail/",strRes,queryData,headers))
     {
         strLastResult = tr("网络连接失败，无法获取索引数据");
         return false;

--- a/Entities/ThreadGuessLyricInfo.h
+++ b/Entities/ThreadGuessLyricInfo.h
@@ -257,7 +257,11 @@ protected:
         queryData.append("csrf_token=&s="+encodedFirst+"+"+ encodedSecond +"&type=1&offset=0&total=True&limit=20");
 
         QString strRes;
-        if(!NetworkAccess::SyncDownloadStringPost( "https://music.163.com/api/v1/search/get",strRes,queryData))
+        QMap<QByteArray, QByteArray> headers = {
+            {"User-Agent", "NeteaseMusic/9.0.90 (iPhone; iOS 17.0; Scale/3.00)"},
+            {"Referer", "https://music.163.com"}
+        };
+        if(!NetworkAccess::SyncDownloadStringPost( "https://music.163.com/api/v1/search/get",strRes,queryData,headers))
         {
             //strLastResult = tr("网络连接失败，无法获取索引数据");
             return false;

--- a/Utility/NetAccess.cpp
+++ b/Utility/NetAccess.cpp
@@ -69,13 +69,14 @@ bool NetworkAccess::SyncDownloadString(const QString strUrl, QString &target, QU
     return bRet;
 }
 
-bool NetworkAccess::SyncDownloadStringPost(const QString strUrl, QString &strSaveBuffer, QByteArray queryData)
+bool NetworkAccess::SyncDownloadStringPost(const QString strUrl, QString &strSaveBuffer, QByteArray queryData, const QMap<QByteArray, QByteArray>& extraHeaders)
 {
     QNetworkRequest request;
     request.setUrl(strUrl);
     request.setRawHeader("Content-Type","application/x-www-form-urlencoded");
-    request.setRawHeader("User-Agent","NeteaseMusic/9.0.90 (iPhone; iOS 17.0; Scale/3.00)");
-    request.setRawHeader("Referer","https://music.163.com");
+
+    for(auto it = extraHeaders.constBegin(); it != extraHeaders.constEnd(); ++it)
+        request.setRawHeader(it.key(), it.value());
 
     QNetworkAccessManager manager;
     QNetworkReply *reply= manager.post(request,queryData);

--- a/Utility/NetAccess.h
+++ b/Utility/NetAccess.h
@@ -10,6 +10,7 @@
 #include <QEventLoop>
 #include <QUrlQuery>
 #include <QQueue>
+#include <QMap>
 
 enum DOWNLOAD_FINISH_STATUS{
     NORMAL,
@@ -46,8 +47,8 @@ public:
     // target 默认存储字符串， 单 targetIsFile = true, 表示路径
     static bool SyncDownloadString(const QString strUrl, QString& target, QUrlQuery query = QUrlQuery(),bool targetIsFile = false);
 
-    /* post 请求下载，下载完成后才返回 */
-    static bool SyncDownloadStringPost(const QString strUrl, QString& strSaveBuffer, QByteArray queryData = QByteArray());
+    /* post 请求下载，下载完成后才返回。extraHeaders 用于附加请求头（如调用网易云接口时所需的 User-Agent/Referer 伪装）。 */
+    static bool SyncDownloadStringPost(const QString strUrl, QString& strSaveBuffer, QByteArray queryData = QByteArray(), const QMap<QByteArray, QByteArray>& extraHeaders = {});
 
 signals:
     void finished();


### PR DESCRIPTION
此前在 #224 中为修复搜索功能，向通用 POST helper 中添加了网易云专属的 User-Agent 和 Referer。由于该 helper 被项目所有 POST 请求共享，长期看 不应携带特定平台的伪装 header。

本次将 SyncDownloadStringPost 改为接受可选的 extraHeaders 参数，由各 网易云调用方（SearcherNetEaseCloud、ThreadGuessLyricInfo、ThreadConvertMp3）自行声明所需 header。helper 恢复通用语义，请求行为与重构前完全等价。